### PR TITLE
use `docker cp` instead of a mount to retrieve the pcaps from the sim

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     hostname: sim
     stdin_open: true
     tty: true
-    volumes:
-      - $SIM_LOGS:/logs
     environment:
       - SCENARIO=$SCENARIO
     cap_add: 


### PR DESCRIPTION
Docker mounts are very slow on OSX when the container performs many writes. It's better to just use `docker cp` to copy over the pcaps after the test run has finished.

Requires https://github.com/marten-seemann/quic-network-simulator/pull/55.