### PR TITLE
add the server's IP address to the client's /etc/hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     networks:
       leftnet:
         ipv4_address: 193.167.0.100
+    extra_hosts:
+      - "server:193.167.100.100"
 
 networks:
   leftnet:


### PR DESCRIPTION
As of https://github.com/marten-seemann/quic-network-simulator/pull/56, we don't add the IP addresses to `/etc/hosts` in the setup script any more. Unfortunately, docker doesn't set up the routing automatically, so we have to add `/etc/hosts` entries in `docker-compose.yml`.

This is a better way than doing it in the setup script, since it is more flexible: The entry is set at container startup, not during the build of the container.