### PR TITLE
use docker cp to copy logs from the endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     tty: true
     volumes:
       - $WWW:/www
-      - $SERVER_LOGS:/logs
     environment:
       - ROLE=server
       - SERVER_PARAMS=$SERVER_PARAMS
@@ -48,7 +47,6 @@ services:
     tty: true
     volumes:
       - $DOWNLOADS:/downloads
-      - $CLIENT_LOGS:/logs
     environment:
       - ROLE=client
       - CLIENT_PARAMS=$CLIENT_PARAMS

--- a/interop.py
+++ b/interop.py
@@ -247,6 +247,16 @@ class InteropRunner:
       "docker cp \"$(docker-compose --log-level ERROR ps -q sim)\":/logs/. " + sim_log_dir.name,
       shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
+    # copy logs from the client
+    subprocess.run(
+      "docker cp \"$(docker-compose --log-level ERROR ps -q client)\":/logs/. " + client_log_dir.name,
+      shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+    # copy logs from the server
+    subprocess.run(
+      "docker cp \"$(docker-compose --log-level ERROR ps -q server)\":/logs/. " + server_log_dir.name,
+      shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
 
     if not expired:
       lines = output.splitlines()


### PR DESCRIPTION
Depends on https://github.com/marten-seemann/quic-network-simulator/pull/62.

Unfortunately, we'll have to ask everyone to rebuild their endpoint image. Also, this doesn't resolve the osxfs problem with the download directory yet.