### PR TITLE
Add high loss test for handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Currently disabled due to #20.
 
 * **HTTP3** (`http3`): Tests a simple HTTP/3 connection. The client is expected to download multiple files using HTTP/3. Files should be requested and transfered in parallel.
 
-* **Handshake Loss** (`multiconnect`): Tests resilience of the handshake to high loss. The client is expected to establish multiple connections, sequential or in parallel, and use each connection to download a single file. Each file is small, of the order of 1KB.
+* **Handshake Loss** (`multiconnect`): Tests resilience of the handshake to high loss. The client is expected to establish multiple connections, sequential or in parallel, and use each connection to download a single file.

--- a/README.md
+++ b/README.md
@@ -39,15 +39,17 @@ The log files are saved to a directory named `#server_#client/#testcase`. `outpu
 
 The Interop Runner implements the following test cases. Unless noted otherwise, test cases use HTTP/0.9 for file transfers. More test cases will be added in the future, to test more protocol features. The name in parentheses is the value of the `TESTCASE` environment variable passed into your Docker container.
 
-* **Version Negotiation** (`versionnegotiation`): This test case tests that a server sends a Version Negotiation packet in response to an unknown QUIC version number. The client should start a connection using an unsupported version number (it can use a reserved version number to do so), and should abort the connection attempt when receiving the Version Negotiation packet.
+* **Version Negotiation** (`versionnegotiation`): Tests that a server sends a Version Negotiation packet in response to an unknown QUIC version number. The client should start a connection using an unsupported version number (it can use a reserved version number to do so), and should abort the connection attempt when receiving the Version Negotiation packet.
 Currently disabled due to #20.
 
-* **Handshake** (`handshake`): This test case tests the successful completion of the handshake. The client is expected to establish a single QUIC connection to the server and download one or multiple small files. Servers should not send a Retry packet in this test case.
+* **Handshake** (`handshake`): Tests the successful completion of the handshake. The client is expected to establish a single QUIC connection to the server and download one or multiple small files. Servers should not send a Retry packet in this test case.
 
-* **Transfer** (`transfer`): This test case tests both flow control and stream multiplexing. The client should use small initial flow control windows for both stream- and connection-level flow control, such that the during the transfer of files on the order of 1 MB the flow control window needs to be increased. The client is exepcted to establish a single QUIC connection, and use multiple streams to concurrently download the files.
+* **Transfer** (`transfer`): Tests both flow control and stream multiplexing. The client should use small initial flow control windows for both stream- and connection-level flow control, such that the during the transfer of files on the order of 1 MB the flow control window needs to be increased. The client is exepcted to establish a single QUIC connection, and use multiple streams to concurrently download the files.
 
-* **Retry** (`retry`): This test case tests that the server can generate a Retry, and that the client can act upon it (i.e. use the Token provided in the Retry packet in the Initial packet).
+* **Retry** (`retry`): Tests that the server can generate a Retry, and that the client can act upon it (i.e. use the Token provided in the Retry packet in the Initial packet).
 
-* **Resumption** (`resumption`): This test cases tests QUIC session resumption (without 0-RTT). The client is expected to establish a connection and download the first file. The server is expected to provide the client with a session ticket that allows it to resume the connection. After downloading the first file, the client has to close the connection, establish a resumed connection using the session ticket, and use this connection to download the remaining file(s).
+* **Resumption** (`resumption`): Tests QUIC session resumption (without 0-RTT). The client is expected to establish a connection and download the first file. The server is expected to provide the client with a session ticket that allows it to resume the connection. After downloading the first file, the client has to close the connection, establish a resumed connection using the session ticket, and use this connection to download the remaining file(s).
 
-* **HTTP3** (`http3`): This test case tests a simple HTTP/3 connection. The client is expected to download multiple files using HTTP/3. Files should be requested and transfered in parallel.
+* **HTTP3** (`http3`): Tests a simple HTTP/3 connection. The client is expected to download multiple files using HTTP/3. Files should be requested and transfered in parallel.
+
+* **Handshake Loss** (`multiconnect`): Tests resilience of the handshake to high loss. The client is expected to establish multiple connections, sequential or in parallel, and use each connection to download a single file. Each file is small, of the order of 1KB.

--- a/testcases.py
+++ b/testcases.py
@@ -370,6 +370,8 @@ class TestCaseBlackhole(TestCase):
 
 
 class TestCaseHandshakeLoss(TestCase):
+  _num_runs = 100
+
   @staticmethod
   def name():
     return "handshakeloss"
@@ -392,14 +394,14 @@ class TestCaseHandshakeLoss(TestCase):
     return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_server=30 --rate_to_client=30"
 
   def get_paths(self):
-    for _ in range(100):
+    for _ in range(self._num_runs):
       self._files.append(self._generate_random_file(1*KB))
     return self._files
 
   def check(self):
     num_handshakes = self._count_handshakes()
-    if num_handshakes != 100:
-      logging.info("Expected 100 handshakes. Got: %d", num_handshakes)
+    if num_handshakes != self._num_runs:
+      logging.info("Expected %d handshakes. Got: %d", self._num_runs, num_handshakes)
       return False
     return self._check_files()
 

--- a/testcases.py
+++ b/testcases.py
@@ -370,7 +370,7 @@ class TestCaseBlackhole(TestCase):
 
 
 class TestCaseHandshakeLoss(TestCase):
-  _num_runs = 100
+  _num_runs = 50
 
   @staticmethod
   def name():

--- a/testcases.py
+++ b/testcases.py
@@ -376,7 +376,7 @@ class TestCaseHandshakeLoss(TestCase):
 
   @staticmethod
   def testname():
-    return "seqtransfer"
+    return "multiconnect"
 
   @staticmethod
   def abbreviation():

--- a/testcases.py
+++ b/testcases.py
@@ -120,6 +120,7 @@ class TestCase(abc.ABC):
   def check(self) -> bool:
     pass
 
+
 class Measurement(TestCase):
   @abc.abstractmethod
   def result(self) -> str:
@@ -134,6 +135,7 @@ class Measurement(TestCase):
   @abc.abstractmethod
   def repetitions() -> int:
     pass
+
 
 class TestCaseVersionNegotiation(TestCase):
   @staticmethod
@@ -164,6 +166,7 @@ class TestCaseVersionNegotiation(TestCase):
     logging.info("Didn't find a Version Negotiation Packet with matching SCID.")
     return False
 
+
 class TestCaseHandshake(TestCase):
   @staticmethod
   def name():
@@ -189,6 +192,7 @@ class TestCaseHandshake(TestCase):
       return False
     return True
 
+
 class TestCaseTransfer(TestCase):
   @staticmethod
   def name():
@@ -212,6 +216,7 @@ class TestCaseTransfer(TestCase):
       logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
       return False
     return self._check_files()
+
 
 class TestCaseMultiplexing(TestCase):
   @staticmethod
@@ -237,6 +242,7 @@ class TestCaseMultiplexing(TestCase):
       logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
       return False
     return self._check_files()
+
 
 class TestCaseRetry(TestCase):
   @staticmethod
@@ -307,6 +313,7 @@ class TestCaseResumption(TestCase):
       return False
     return self._check_files()
 
+
 class TestCaseHTTP3(TestCase):
   @staticmethod
   def name():
@@ -330,6 +337,7 @@ class TestCaseHTTP3(TestCase):
       logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
       return False
     return self._check_files()
+
 
 class TestCaseBlackhole(TestCase):
   @staticmethod
@@ -360,6 +368,7 @@ class TestCaseBlackhole(TestCase):
       return False
     return self._check_files()
 
+
 class TestCaseHandshakeLoss(TestCase):
   @staticmethod
   def name():
@@ -367,28 +376,33 @@ class TestCaseHandshakeLoss(TestCase):
 
   @staticmethod
   def testname():
-    return "transfer"
+    return "seqtransfer"
 
   @staticmethod
   def abbreviation():
-    return "HL"
+    return "L"
+
+  @staticmethod
+  def timeout() -> int:
+    return 300
 
   @staticmethod
   def scenario() -> str:
     """ Scenario for the ns3 simulator """
-    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=30 --rate_to_server=0"
+    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_server=30 --rate_to_client=30"
 
   def get_paths(self):
-    for _ in range(1, 10):
+    for _ in range(100):
       self._files.append(self._generate_random_file(1*KB))
     return self._files
 
   def check(self):
     num_handshakes = self._count_handshakes()
-    if num_handshakes != 10:
-      logging.info("Expected 10 handshakes. Got: %d", num_handshakes)
+    if num_handshakes != 100:
+      logging.info("Expected 100 handshakes. Got: %d", num_handshakes)
       return False
     return self._check_files()
+
 
 class MeasurementGoodput(Measurement):
   FILESIZE = 10*MB
@@ -444,6 +458,7 @@ class MeasurementGoodput(Measurement):
   def result(self) -> float:
     return self._result
 
+
 class MeasurementCrossTraffic(MeasurementGoodput):
   FILESIZE=25*MB
 
@@ -466,6 +481,7 @@ class MeasurementCrossTraffic(MeasurementGoodput):
   @staticmethod
   def additional_containers() -> List[str]:
     return [ "iperf_server", "iperf_client" ]
+
 
 TESTCASES = [ 
   TestCaseHandshake,

--- a/testcases.py
+++ b/testcases.py
@@ -360,6 +360,33 @@ class TestCaseBlackhole(TestCase):
       return False
     return self._check_files()
 
+class TestCaseHighLoss(TestCase):
+  @staticmethod
+  def name():
+    return "highloss"
+
+  @staticmethod
+  def testname():
+    return "transfer"
+
+  @staticmethod
+  def abbreviation():
+    return "L"
+
+  @staticmethod
+  def scenario() -> str:
+    """ Scenario for the ns3 simulator """
+    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=0 --rate_to_server=10"
+
+  def get_paths(self):
+    self._files = [ self._generate_random_file(1*KB) ]
+    return self._files
+
+  def check(self):
+    c = self._check_files()
+    print("check", c)
+    return c
+
 class MeasurementGoodput(Measurement):
   FILESIZE = 10*MB
   _result = 0.0

--- a/testcases.py
+++ b/testcases.py
@@ -360,10 +360,10 @@ class TestCaseBlackhole(TestCase):
       return False
     return self._check_files()
 
-class TestCaseHighLoss(TestCase):
+class TestCaseHandshakeLoss(TestCase):
   @staticmethod
   def name():
-    return "highloss"
+    return "handshakeloss"
 
   @staticmethod
   def testname():
@@ -371,21 +371,24 @@ class TestCaseHighLoss(TestCase):
 
   @staticmethod
   def abbreviation():
-    return "L"
+    return "HL"
 
   @staticmethod
   def scenario() -> str:
     """ Scenario for the ns3 simulator """
-    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=0 --rate_to_server=10"
+    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=30 --rate_to_server=0"
 
   def get_paths(self):
-    self._files = [ self._generate_random_file(1*KB) ]
+    for _ in range(1, 10):
+      self._files.append(self._generate_random_file(1*KB))
     return self._files
 
   def check(self):
-    c = self._check_files()
-    print("check", c)
-    return c
+    num_handshakes = self._count_handshakes()
+    if num_handshakes != 10:
+      logging.info("Expected 10 handshakes. Got: %d", num_handshakes)
+      return False
+    return self._check_files()
 
 class MeasurementGoodput(Measurement):
   FILESIZE = 10*MB
@@ -472,6 +475,7 @@ TESTCASES = [
   TestCaseResumption,
   TestCaseHTTP3,
   TestCaseBlackhole,
+  TestCaseHandshakeLoss,
 ]
 
 MEASUREMENTS = [


### PR DESCRIPTION
Fixes #27.

Tests creation of 100 connections, at 30% loss in each direction, to ensure connection setup resiliency to high loss.

This test uses a new "multiconnect" testcase that requires a client to use a separate connection for each request.