### PR TITLE
fix handshake counting

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -102,7 +102,7 @@ class TestCase(abc.ABC):
     tr = TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap")
     # Determine the number of handshakes by looking at Handshake packets.
     # This is easier, since the DCID of Handshake packets doesn't changes.
-    return len(set([ p.dcid for p in tr.get_handshake(Direction.FROM_CLIENT) ]))
+    return len(set([ p.scid for p in tr.get_initial(Direction.FROM_SERVER) ]))
 
   def cleanup(self):
     if self._www_dir:


### PR DESCRIPTION
Fixes #55. Depends on #56.

It's easier to look at the SCID of Initial packets sent from the server. The server shouldn't send any Initial packets after receiving a NCID frame (which is sent in 1-RTT packets), so we won't get an inflated count that way.
Furthermore, unless the server does stupid things, it will use a non-zero CID.