### PR TITLE
check that the client doesn't use 0-RTT in resumption test

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -104,6 +104,13 @@ class TestCase(abc.ABC):
     # This is easier, since the DCID of Handshake packets doesn't changes.
     return len(set([ p.scid for p in tr.get_initial(Direction.FROM_SERVER) ]))
 
+  def _payload_size(self, packets: List) -> int:
+    """ Get the sum of the payload sizes of all packets """
+    size = 0
+    for p in packets:
+      size += len(p.remaining_payload.split(":"))
+    return size
+
   def cleanup(self):
     if self._www_dir:
       self._www_dir.cleanup()
@@ -311,8 +318,29 @@ class TestCaseResumption(TestCase):
     if num_handshakes != 2:
       logging.info("Expected exactly 2 handshake. Got: %d", num_handshakes)
       return False
-    if len(TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap").get_0rtt()) != 0:
+    tr = TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap")
+    if len(tr.get_0rtt()) != 0:
       logging.info("Client sent 0-RTT packets.")
+      return False
+
+    handshake_packets = tr.get_handshake(Direction.FROM_SERVER)
+    cids = [ p.scid for p in handshake_packets ]
+    handshake_packets_first = []
+    handshake_packets_second = []
+    for p in handshake_packets:
+      if p.scid == cids[0]:
+        handshake_packets_first.append(p)
+      elif p.scid == cids[len(cids)-1]:
+        handshake_packets_second.append(p)
+      else:
+        logging.info("This should never happen.")
+        return False
+    handshake_size_first = self._payload_size(handshake_packets_first)
+    handshake_size_second = self._payload_size(handshake_packets_second)
+    logging.debug("Size of the server's Handshake flight (1st connection): %d", handshake_size_first)
+    logging.debug("Size of the server's Handshake flight (2nd connection): %d", handshake_size_second)
+    if handshake_size_first < handshake_size_second + 500:
+      logging.info("Expected the size of the server's Handshake flight to be significantly smaller during the second connection.")
       return False
     return self._check_files()
 

--- a/testcases.py
+++ b/testcases.py
@@ -311,6 +311,9 @@ class TestCaseResumption(TestCase):
     if num_handshakes != 2:
       logging.info("Expected exactly 2 handshake. Got: %d", num_handshakes)
       return False
+    if len(TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap").get_0rtt()) != 0:
+      logging.info("Client sent 0-RTT packets.")
+      return False
     return self._check_files()
 
 

--- a/trace.py
+++ b/trace.py
@@ -74,3 +74,12 @@ class TraceAnalyzer:
         if layer.layer_name == "quic" and hasattr(layer, "long_packet_type") and layer.long_packet_type == "2":
           packets.append(layer)
     return packets
+
+  def get_0rtt(self) -> List:
+    """ Get all Handshake packets. """
+    packets = []
+    for packet in self._get_packets(self._get_direction_filter(Direction.FROM_CLIENT) + "quic.long.packet_type"):
+      for layer in packet.layers:
+        if layer.layer_name == "quic" and hasattr(layer, "long_packet_type") and layer.long_packet_type == "1":
+          packets.append(layer)
+    return packets


### PR DESCRIPTION
DO NOT MERGE.

In preparation for the 0-RTT test.

This PR adds two more checks for the resumption test:
1. The client MUST NOT send any 0-RTT packets. This test is for session resumption, not for 0-RTT (as we made clear in the README).
2. The server's handshake flight should be significantly smaller during the second connection (because it doesn't need to send the certificate any more). This PR assumes somewhat arbitrarily that the certificate will weigh at least 500 bytes, which seems to work out in practice as far as I can see, but maybe we will need to modify this check, if this condition fails handshakes legitimate session resumptions.

Local tests showed that many implementations fail at least one of the two conditions.