### PR TITLE
Print exceptions raised by pyshark

### DIFF
--- a/trace.py
+++ b/trace.py
@@ -32,8 +32,8 @@ class TraceAnalyzer:
       for p in cap:
         packets.append(p)
       cap.close()
-    except:
-      pass
+    except Exception as e:
+      print(e)
     return packets
 
   def get_1rtt(self, direction: Direction = Direction.ALL) -> List:


### PR DESCRIPTION
This helps debug situations such as `tshark` not being on the PATH. For
instance on Debian, `tshark` is packaged separately from `wireshark`.