### PR TITLE
Reformat code using `black`, sort imports using `isort`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+dist: xenial
+install: pip install -r requirements.txt black flake8 isort
+language: python
+python: "3.8"
+script: .travis/script
+sudo: true

--- a/.travis/script
+++ b/.travis/script
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+flake8 *.py
+isort -c -df *.py
+black --check --diff *.py

--- a/implementations.py
+++ b/implementations.py
@@ -1,12 +1,12 @@
 # add your QUIC implementation here
-IMPLEMENTATIONS = { # name => [ docker image, role ]; role: 0 == 'client', 1 == 'server', 2 == both
-  "quicgo": { "url": "martenseemann/quic-go-interop:latest", "role": 2 },
-  "quicly": { "url": "janaiyengar/quicly:interop", "role": 2 },
-  "ngtcp2": { "url": "ngtcp2/ngtcp2-interop:latest", "role": 2 },
-  "quant":  { "url": "ntap/quant:interop", "role": 2 },
-  "mvfst":  { "url": "lnicco/mvfst-qns:latest", "role": 2 },
-  "quiche": { "url": "cloudflare/quiche-qns:latest", "role": 2 },
-  "kwik":   { "url": "peterdoornbosch/kwik_n_flupke-interop", "role": 0 },
-  "picoquic": { "url": "privateoctopus/picoquic:latest", "role":2 },
-  "aioquic": { "url": "aiortc/aioquic-qns:latest", "role": 2 },
+IMPLEMENTATIONS = {  # name => [ docker image, role ]; role: 0 == 'client', 1 == 'server', 2 == both
+    "quicgo": {"url": "martenseemann/quic-go-interop:latest", "role": 2},
+    "quicly": {"url": "janaiyengar/quicly:interop", "role": 2},
+    "ngtcp2": {"url": "ngtcp2/ngtcp2-interop:latest", "role": 2},
+    "quant": {"url": "ntap/quant:interop", "role": 2},
+    "mvfst": {"url": "lnicco/mvfst-qns:latest", "role": 2},
+    "quiche": {"url": "cloudflare/quiche-qns:latest", "role": 2},
+    "kwik": {"url": "peterdoornbosch/kwik_n_flupke-interop", "role": 0},
+    "picoquic": {"url": "privateoctopus/picoquic:latest", "role": 2},
+    "aioquic": {"url": "aiortc/aioquic-qns:latest", "role": 2},
 }

--- a/interop.py
+++ b/interop.py
@@ -1,359 +1,460 @@
-import json, os, random, shutil, subprocess, string, logging, statistics, tempfile, re
+import json
+import logging
+import os
+import random
+import re
+import shutil
+import statistics
+import string
+import subprocess
+import tempfile
 from datetime import datetime
-from typing import Callable, List, Tuple
-from termcolor import colored
 from enum import Enum
+from typing import Callable, List, Tuple
+
 import prettytable
+from termcolor import colored
 
 import testcases
 
 
 def random_string(length: int):
-  """ Generate a random string of fixed length """
-  letters = string.ascii_lowercase
-  return ''.join(random.choice(letters) for i in range(length))
+    """ Generate a random string of fixed length """
+    letters = string.ascii_lowercase
+    return "".join(random.choice(letters) for i in range(length))
+
 
 class TestResult(Enum):
-  SUCCEEDED = "succeeded"
-  FAILED = "failed"
-  UNSUPPORTED = "unsupported"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    UNSUPPORTED = "unsupported"
+
 
 class MeasurementResult:
-  result = TestResult
-  details = str
+    result = TestResult
+    details = str
+
 
 class LogFileFormatter(logging.Formatter):
-  def format(self, record):
-    msg = super(LogFileFormatter, self).format(record)
-    # remove color control characters
-    return re.compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]').sub('', msg)
+    def format(self, record):
+        msg = super(LogFileFormatter, self).format(record)
+        # remove color control characters
+        return re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]").sub("", msg)
+
 
 class InteropRunner:
-  _start_time = 0
-  test_results = {}
-  measurement_results = {}
-  compliant = {}
-  _implementations = {}
-  _servers = []
-  _clients = []
-  _tests = []
-  _measurements = []
-  _output = ""
+    _start_time = 0
+    test_results = {}
+    measurement_results = {}
+    compliant = {}
+    _implementations = {}
+    _servers = []
+    _clients = []
+    _tests = []
+    _measurements = []
+    _output = ""
 
-  def __init__(self, implementations: dict, servers: List[str], clients: List[str], tests: List[testcases.TestCase], measurements: List[testcases.Measurement], output: str):
-    self._start_time = datetime.now()
-    self._tests = tests
-    self._measurements = measurements
-    self._servers = servers
-    self._clients = clients
-    self._implementations = implementations
-    self._output = output
-    for server in servers:
-      self.test_results[server] = {}
-      self.measurement_results[server] = {}
-      for client in clients:
-        self.test_results[server][client] = {}
-        for test in self._tests:
-          self.test_results[server][client][test] = {}
-        self.measurement_results[server][client] = {}
-        for measurement in measurements:
-          self.measurement_results[server][client][measurement] = {}
+    def __init__(
+        self,
+        implementations: dict,
+        servers: List[str],
+        clients: List[str],
+        tests: List[testcases.TestCase],
+        measurements: List[testcases.Measurement],
+        output: str,
+    ):
+        self._start_time = datetime.now()
+        self._tests = tests
+        self._measurements = measurements
+        self._servers = servers
+        self._clients = clients
+        self._implementations = implementations
+        self._output = output
+        for server in servers:
+            self.test_results[server] = {}
+            self.measurement_results[server] = {}
+            for client in clients:
+                self.test_results[server][client] = {}
+                for test in self._tests:
+                    self.test_results[server][client][test] = {}
+                self.measurement_results[server][client] = {}
+                for measurement in measurements:
+                    self.measurement_results[server][client][measurement] = {}
 
-  def _is_unsupported(self, lines: List[str]) -> bool:
-    return any("exited with code 127" in str(l) for l in lines) or any("exit status 127" in str(l) for l in lines)
+    def _is_unsupported(self, lines: List[str]) -> bool:
+        return any("exited with code 127" in str(l) for l in lines) or any(
+            "exit status 127" in str(l) for l in lines
+        )
 
-  def _check_impl_is_compliant(self, name: str) -> bool:
-    """ check if an implementation return UNSUPPORTED for unknown test cases """
-    if name in self.compliant:
-      logging.debug("%s already tested for compliance: %s", name, str(self.compliant))
-      return self.compliant[name]
+    def _check_impl_is_compliant(self, name: str) -> bool:
+        """ check if an implementation return UNSUPPORTED for unknown test cases """
+        if name in self.compliant:
+            logging.debug(
+                "%s already tested for compliance: %s", name, str(self.compliant)
+            )
+            return self.compliant[name]
 
-    client_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_client_")
-    www_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="compliance_www_")
-    downloads_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="compliance_downloads_")
+        client_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_client_")
+        www_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="compliance_www_")
+        downloads_dir = tempfile.TemporaryDirectory(
+            dir="/tmp", prefix="compliance_downloads_"
+        )
 
-    # check that the client is capable of returning UNSUPPORTED
-    logging.debug("Checking compliance of %s client", name)
-    cmd = (
-        "TESTCASE=" + random_string(6) + " "
-        "SERVER_LOGS=/dev/null "
-        "CLIENT_LOGS=" + client_log_dir.name + " "
-        "WWW=" + www_dir.name + " "
-        "DOWNLOADS=" + downloads_dir.name + " "
-        "SCENARIO=\"simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25\" "
-        "CLIENT=" + self._implementations[name] + " "
-        "docker-compose up --timeout 0 --abort-on-container-exit sim client"
-      )
-    output = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    if not self._is_unsupported(output.stdout.splitlines()):
-      logging.error("%s client not compliant.", name)
-      logging.debug("%s", output.stdout.decode('utf-8'))
-      self.compliant[name] = False
-      return False
-    logging.debug("%s client compliant.", name)
+        # check that the client is capable of returning UNSUPPORTED
+        logging.debug("Checking compliance of %s client", name)
+        cmd = (
+            "TESTCASE=" + random_string(6) + " "
+            "SERVER_LOGS=/dev/null "
+            "CLIENT_LOGS=" + client_log_dir.name + " "
+            "WWW=" + www_dir.name + " "
+            "DOWNLOADS=" + downloads_dir.name + " "
+            'SCENARIO="simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25" '
+            "CLIENT=" + self._implementations[name] + " "
+            "docker-compose up --timeout 0 --abort-on-container-exit sim client"
+        )
+        output = subprocess.run(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        if not self._is_unsupported(output.stdout.splitlines()):
+            logging.error("%s client not compliant.", name)
+            logging.debug("%s", output.stdout.decode("utf-8"))
+            self.compliant[name] = False
+            return False
+        logging.debug("%s client compliant.", name)
 
-    # check that the server is capable of returning UNSUPPORTED
-    logging.debug("Checking compliance of %s server", name)
-    server_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_server_")
-    cmd = (
-        "TESTCASE=" + random_string(6) + " "
-        "SERVER_LOGS=" + server_log_dir.name + " "
-        "CLIENT_LOGS=/dev/null "
-        "WWW=" + www_dir.name + " "
-        "DOWNLOADS=" + downloads_dir.name + " "
-        "SERVER=" + self._implementations[name] + " "
-        "docker-compose up server"
-      )
-    output = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    if not self._is_unsupported(output.stdout.splitlines()):
-      logging.error("%s server not compliant.", name)
-      logging.debug("%s", output.stdout.decode('utf-8'))
-      self.compliant[name] = False
-      return False
-    logging.info("%s server compliant.", name)
-    
-    # remember compliance test outcome
-    self.compliant[name] = True
-    return True
+        # check that the server is capable of returning UNSUPPORTED
+        logging.debug("Checking compliance of %s server", name)
+        server_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_server_")
+        cmd = (
+            "TESTCASE=" + random_string(6) + " "
+            "SERVER_LOGS=" + server_log_dir.name + " "
+            "CLIENT_LOGS=/dev/null "
+            "WWW=" + www_dir.name + " "
+            "DOWNLOADS=" + downloads_dir.name + " "
+            "SERVER=" + self._implementations[name] + " "
+            "docker-compose up server"
+        )
+        output = subprocess.run(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        if not self._is_unsupported(output.stdout.splitlines()):
+            logging.error("%s server not compliant.", name)
+            logging.debug("%s", output.stdout.decode("utf-8"))
+            self.compliant[name] = False
+            return False
+        logging.info("%s server compliant.", name)
 
+        # remember compliance test outcome
+        self.compliant[name] = True
+        return True
 
-  def _print_results(self):
-    """print the interop table"""
-    logging.info("Run took %s", datetime.now() - self._start_time)
-    def get_letters(result):
-      return "".join([ test.abbreviation() for test in cell if cell[test] is result ])
-    
-    if len(self._tests) > 0:
-      t = prettytable.PrettyTable()
-      t.hrules = prettytable.ALL
-      t.vrules = prettytable.ALL
-      t.field_names = [ "" ] + [ name for name in self._servers ]
-      for client in self._clients:
-        row = [ client ]
-        for server in self._servers:
-          cell = self.test_results[server][client]
-          res = colored(get_letters(TestResult.SUCCEEDED), "green") + "\n"
-          res += colored(get_letters(TestResult.UNSUPPORTED), "yellow") + "\n"
-          res += colored(get_letters(TestResult.FAILED), "red")
-          row += [ res ]
-        t.add_row(row)
-      print(t)
-    
-    if len(self._measurements) > 0:
-      t = prettytable.PrettyTable()
-      t.hrules = prettytable.ALL
-      t.vrules = prettytable.ALL
-      t.field_names = [ "" ] + [ name for name in self._servers ]
-      for client in self._clients:
-        row = [ client ]
-        for server in self._servers:
-          cell = self.measurement_results[server][client]
-          results = []
-          for measurement in self._measurements:
-            res = cell[measurement]
-            if not hasattr(res, "result"):
-              continue
-            if res.result == TestResult.SUCCEEDED:
-              results.append(colored(measurement.abbreviation() + ": " + res.details, "green"))
-            elif res.result == TestResult.UNSUPPORTED:
-              results.append(colored(measurement.abbreviation(), "yellow"))
-            elif res.result == TestResult.FAILED:
-              results.append(colored(measurement.abbreviation(), "red"))
-          row += [ "\n".join(results) ]
-        t.add_row(row)
-      print(t)
+    def _print_results(self):
+        """print the interop table"""
+        logging.info("Run took %s", datetime.now() - self._start_time)
 
-  def _export_results(self):
-    if not self._output:
-      return
+        def get_letters(result):
+            return "".join(
+                [test.abbreviation() for test in cell if cell[test] is result]
+            )
 
-    out = {
-      "start_time": self._start_time.timestamp(),
-      "end_time": datetime.now().timestamp(),
-      "servers": [ name for name in self._servers ],
-      "clients": [ name for name in self._clients ],
-      "results": [],
-      "measurements": [],
-    }
-      
-    for client in self._clients:
-      for server in self._servers:
-        results = []
-        for test in self._tests:
-          results.append({
-            "abbr": test.abbreviation(),
-            "name": test.name(),
-            "result": self.test_results[server][client][test].value,
-          })
-        out["results"].append(results)
-       
-        measurements = []
-        for measurement in self._measurements:
-          res = self.measurement_results[server][client][measurement]
-          if not hasattr(res, "result"):
-            continue
-          measurements.append({
-            "name": measurement.name(),
-            "abbr": measurement.abbreviation(),
-            "result": res.result.value,
-            "details": res.details,
-          })
-        out["measurements"].append(measurements)
+        if len(self._tests) > 0:
+            t = prettytable.PrettyTable()
+            t.hrules = prettytable.ALL
+            t.vrules = prettytable.ALL
+            t.field_names = [""] + [name for name in self._servers]
+            for client in self._clients:
+                row = [client]
+                for server in self._servers:
+                    cell = self.test_results[server][client]
+                    res = colored(get_letters(TestResult.SUCCEEDED), "green") + "\n"
+                    res += colored(get_letters(TestResult.UNSUPPORTED), "yellow") + "\n"
+                    res += colored(get_letters(TestResult.FAILED), "red")
+                    row += [res]
+                t.add_row(row)
+            print(t)
 
-    f = open(self._output, "w")
-    json.dump(out, f)
-    f.close()
+        if len(self._measurements) > 0:
+            t = prettytable.PrettyTable()
+            t.hrules = prettytable.ALL
+            t.vrules = prettytable.ALL
+            t.field_names = [""] + [name for name in self._servers]
+            for client in self._clients:
+                row = [client]
+                for server in self._servers:
+                    cell = self.measurement_results[server][client]
+                    results = []
+                    for measurement in self._measurements:
+                        res = cell[measurement]
+                        if not hasattr(res, "result"):
+                            continue
+                        if res.result == TestResult.SUCCEEDED:
+                            results.append(
+                                colored(
+                                    measurement.abbreviation() + ": " + res.details,
+                                    "green",
+                                )
+                            )
+                        elif res.result == TestResult.UNSUPPORTED:
+                            results.append(
+                                colored(measurement.abbreviation(), "yellow")
+                            )
+                        elif res.result == TestResult.FAILED:
+                            results.append(colored(measurement.abbreviation(), "red"))
+                    row += ["\n".join(results)]
+                t.add_row(row)
+            print(t)
 
-  def _run_testcase(self, server: str, client: str, test: Callable[[], testcases.TestCase]) -> TestResult:
-    return self._run_test(server, client, None, test)[0]
+    def _export_results(self):
+        if not self._output:
+            return
 
-  def _run_test(self, server: str, client: str, log_dir_prefix: None, test: Callable[[], testcases.TestCase]) -> Tuple[TestResult, float]:
-    start_time = datetime.now()
-    sim_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_sim_")
-    server_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_server_")
-    client_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_client_")
-    log_file = tempfile.NamedTemporaryFile(dir="/tmp", prefix="output_log_")
-    log_handler = logging.FileHandler(log_file.name)
-    log_handler.setLevel(logging.DEBUG)
+        out = {
+            "start_time": self._start_time.timestamp(),
+            "end_time": datetime.now().timestamp(),
+            "servers": [name for name in self._servers],
+            "clients": [name for name in self._clients],
+            "results": [],
+            "measurements": [],
+        }
 
-    formatter = LogFileFormatter('%(asctime)s %(message)s')
-    log_handler.setFormatter(formatter)
-    logging.getLogger().addHandler(log_handler)
+        for client in self._clients:
+            for server in self._servers:
+                results = []
+                for test in self._tests:
+                    results.append(
+                        {
+                            "abbr": test.abbreviation(),
+                            "name": test.name(),
+                            "result": self.test_results[server][client][test].value,
+                        }
+                    )
+                out["results"].append(results)
 
-    testcase = test(sim_log_dir=sim_log_dir, client_keylog_file=client_log_dir.name + "/keys.log")
-    print("Server: " + server + ". Client: " + client + ". Running test case: " + str(testcase))
+                measurements = []
+                for measurement in self._measurements:
+                    res = self.measurement_results[server][client][measurement]
+                    if not hasattr(res, "result"):
+                        continue
+                    measurements.append(
+                        {
+                            "name": measurement.name(),
+                            "abbr": measurement.abbreviation(),
+                            "result": res.result.value,
+                            "details": res.details,
+                        }
+                    )
+                out["measurements"].append(measurements)
 
-    reqs = " ".join(["https://server:443/" + p for p in testcase.get_paths()])
-    logging.debug("Requests: %s", reqs)
-    params = (
-      "TESTCASE=" + testcase.testname() + " "
-      "WWW=" + testcase.www_dir() + " "
-      "DOWNLOADS=" + testcase.download_dir() + " "
-      "SERVER_LOGS=" + server_log_dir.name + " "
-      "CLIENT_LOGS=" + client_log_dir.name + " "
-      "SCENARIO=\"{}\" "
-      "CLIENT=" + self._implementations[client] + " "
-      "SERVER=" + self._implementations[server] + " "
-      "REQUESTS=\"" + reqs + "\" "
-    ).format(testcase.scenario())
-    params += " ".join(testcase.additional_envs())
-    containers = "sim client server " + " ".join(testcase.additional_containers())
-    cmd = params + " docker-compose up --abort-on-container-exit --timeout 1 " + containers
-    logging.debug("Command: %s", cmd)
+        f = open(self._output, "w")
+        json.dump(out, f)
+        f.close()
 
-    status = TestResult.FAILED
-    output = ""
-    expired = False
-    try:
-      r = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=testcase.timeout())
-      output = r.stdout
-    except subprocess.TimeoutExpired as ex:
-      output = ex.stdout
-      expired = True
+    def _run_testcase(
+        self, server: str, client: str, test: Callable[[], testcases.TestCase]
+    ) -> TestResult:
+        return self._run_test(server, client, None, test)[0]
 
-    logging.debug("%s", output.decode('utf-8'))
+    def _run_test(
+        self,
+        server: str,
+        client: str,
+        log_dir_prefix: None,
+        test: Callable[[], testcases.TestCase],
+    ) -> Tuple[TestResult, float]:
+        start_time = datetime.now()
+        sim_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_sim_")
+        server_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_server_")
+        client_log_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="logs_client_")
+        log_file = tempfile.NamedTemporaryFile(dir="/tmp", prefix="output_log_")
+        log_handler = logging.FileHandler(log_file.name)
+        log_handler.setLevel(logging.DEBUG)
 
-    if expired:
-      logging.debug("Test failed: took longer than %ds.", testcase.timeout())
-      r = subprocess.run("docker-compose stop " + containers, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=60)
-      logging.debug("%s", r.stdout.decode('utf-8'))
+        formatter = LogFileFormatter("%(asctime)s %(message)s")
+        log_handler.setFormatter(formatter)
+        logging.getLogger().addHandler(log_handler)
 
-    # copy the pcaps from the simulator
-    subprocess.run(
-      "docker cp \"$(docker-compose --log-level ERROR ps -q sim)\":/logs/. " + sim_log_dir.name,
-      shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
-    # copy logs from the client
-    subprocess.run(
-      "docker cp \"$(docker-compose --log-level ERROR ps -q client)\":/logs/. " + client_log_dir.name,
-      shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
-    # copy logs from the server
-    subprocess.run(
-      "docker cp \"$(docker-compose --log-level ERROR ps -q server)\":/logs/. " + server_log_dir.name,
-      shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
+        testcase = test(
+            sim_log_dir=sim_log_dir,
+            client_keylog_file=client_log_dir.name + "/keys.log",
+        )
+        print(
+            "Server: "
+            + server
+            + ". Client: "
+            + client
+            + ". Running test case: "
+            + str(testcase)
+        )
 
-    if not expired:
-      lines = output.splitlines()
-      if self._is_unsupported(lines):
-        status = TestResult.UNSUPPORTED
-      elif any("client exited with code 0" in str(l) for l in lines):
-        if testcase.check():
-          status = TestResult.SUCCEEDED
+        reqs = " ".join(["https://server:443/" + p for p in testcase.get_paths()])
+        logging.debug("Requests: %s", reqs)
+        params = (
+            "TESTCASE=" + testcase.testname() + " "
+            "WWW=" + testcase.www_dir() + " "
+            "DOWNLOADS=" + testcase.download_dir() + " "
+            "SERVER_LOGS=" + server_log_dir.name + " "
+            "CLIENT_LOGS=" + client_log_dir.name + " "
+            'SCENARIO="{}" '
+            "CLIENT=" + self._implementations[client] + " "
+            "SERVER=" + self._implementations[server] + " "
+            'REQUESTS="' + reqs + '" '
+        ).format(testcase.scenario())
+        params += " ".join(testcase.additional_envs())
+        containers = "sim client server " + " ".join(testcase.additional_containers())
+        cmd = (
+            params
+            + " docker-compose up --abort-on-container-exit --timeout 1 "
+            + containers
+        )
+        logging.debug("Command: %s", cmd)
 
-    # save logs
-    logging.getLogger().removeHandler(log_handler)
-    log_handler.close()
-    if status == TestResult.FAILED or status == TestResult.SUCCEEDED:
-      log_dir = "logs/" + server + "_" + client + "/" + str(testcase)
-      if log_dir_prefix:
-        log_dir += "/" + log_dir_prefix
-      shutil.copytree(server_log_dir.name, log_dir + "/server")
-      shutil.copytree(client_log_dir.name, log_dir + "/client")
-      shutil.copytree(sim_log_dir.name, log_dir + "/sim")
-      shutil.copyfile(log_file.name, log_dir + "/output.txt")
-      if status == TestResult.FAILED:
-        shutil.copytree(testcase.www_dir(), log_dir + "/www")
+        status = TestResult.FAILED
+        output = ""
+        expired = False
         try:
-          shutil.copytree(testcase.download_dir(), log_dir + "/downloads")
-        except Exception as exception:
-          logging.info("Could not copy downloaded files: %s", exception)
+            r = subprocess.run(
+                cmd,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=testcase.timeout(),
+            )
+            output = r.stdout
+        except subprocess.TimeoutExpired as ex:
+            output = ex.stdout
+            expired = True
 
-    testcase.cleanup()
-    server_log_dir.cleanup()
-    client_log_dir.cleanup()
-    sim_log_dir.cleanup()
-    logging.debug("Test took %ss", (datetime.now()-start_time).total_seconds())
+        logging.debug("%s", output.decode("utf-8"))
 
-    # measurements also have a value
-    if hasattr(testcase, "result"):
-        value = testcase.result()
-    else:
-        value = None
+        if expired:
+            logging.debug("Test failed: took longer than %ds.", testcase.timeout())
+            r = subprocess.run(
+                "docker-compose stop " + containers,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=60,
+            )
+            logging.debug("%s", r.stdout.decode("utf-8"))
 
-    return status, value
+        # copy the pcaps from the simulator
+        subprocess.run(
+            'docker cp "$(docker-compose --log-level ERROR ps -q sim)":/logs/. '
+            + sim_log_dir.name,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        # copy logs from the client
+        subprocess.run(
+            'docker cp "$(docker-compose --log-level ERROR ps -q client)":/logs/. '
+            + client_log_dir.name,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        # copy logs from the server
+        subprocess.run(
+            'docker cp "$(docker-compose --log-level ERROR ps -q server)":/logs/. '
+            + server_log_dir.name,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
 
-  def _run_measurement(self, server: str, client: str, test: Callable[[], testcases.Measurement]) -> MeasurementResult:
-    values = []
-    for i in range (0, test.repetitions()):
-      result, value = self._run_test(server, client, "%d" % (i+1), test)
-      if result != TestResult.SUCCEEDED:
+        if not expired:
+            lines = output.splitlines()
+            if self._is_unsupported(lines):
+                status = TestResult.UNSUPPORTED
+            elif any("client exited with code 0" in str(l) for l in lines):
+                if testcase.check():
+                    status = TestResult.SUCCEEDED
+
+        # save logs
+        logging.getLogger().removeHandler(log_handler)
+        log_handler.close()
+        if status == TestResult.FAILED or status == TestResult.SUCCEEDED:
+            log_dir = "logs/" + server + "_" + client + "/" + str(testcase)
+            if log_dir_prefix:
+                log_dir += "/" + log_dir_prefix
+            shutil.copytree(server_log_dir.name, log_dir + "/server")
+            shutil.copytree(client_log_dir.name, log_dir + "/client")
+            shutil.copytree(sim_log_dir.name, log_dir + "/sim")
+            shutil.copyfile(log_file.name, log_dir + "/output.txt")
+            if status == TestResult.FAILED:
+                shutil.copytree(testcase.www_dir(), log_dir + "/www")
+                try:
+                    shutil.copytree(testcase.download_dir(), log_dir + "/downloads")
+                except Exception as exception:
+                    logging.info("Could not copy downloaded files: %s", exception)
+
+        testcase.cleanup()
+        server_log_dir.cleanup()
+        client_log_dir.cleanup()
+        sim_log_dir.cleanup()
+        logging.debug("Test took %ss", (datetime.now() - start_time).total_seconds())
+
+        # measurements also have a value
+        if hasattr(testcase, "result"):
+            value = testcase.result()
+        else:
+            value = None
+
+        return status, value
+
+    def _run_measurement(
+        self, server: str, client: str, test: Callable[[], testcases.Measurement]
+    ) -> MeasurementResult:
+        values = []
+        for i in range(0, test.repetitions()):
+            result, value = self._run_test(server, client, "%d" % (i + 1), test)
+            if result != TestResult.SUCCEEDED:
+                res = MeasurementResult()
+                res.result = result
+                res.details = ""
+                return res
+            values.append(value)
+
+        logging.debug(values)
         res = MeasurementResult()
-        res.result = result
-        res.details = ""
+        res.result = TestResult.SUCCEEDED
+        res.details = "{:.0f} (± {:.0f}) {}".format(
+            statistics.mean(values), statistics.stdev(values), test.unit()
+        )
         return res
-      values.append(value)
 
-    logging.debug(values)    
-    res = MeasurementResult()
-    res.result = TestResult.SUCCEEDED
-    res.details = "{:.0f} (± {:.0f}) {}".format(statistics.mean(values), statistics.stdev(values), test.unit())
-    return res
+    def run(self):
+        """run the interop test suite and output the table"""
 
-  def run(self):
-    """run the interop test suite and output the table"""
+        # clear the logs directory
+        if os.path.exists("logs/"):
+            shutil.rmtree("logs/")
 
-    # clear the logs directory
-    if os.path.exists("logs/"):
-      shutil.rmtree("logs/")
-    
-    for server in self._servers:
-      for client in self._clients:
-        logging.info("Running with server %s (%s) and client %s (%s)", server, self._implementations[server], client, self._implementations[client])
-        if not (self._check_impl_is_compliant(server) and self._check_impl_is_compliant(client)):
-          logging.info("Not compliant, skipping")
-          continue
+        for server in self._servers:
+            for client in self._clients:
+                logging.info(
+                    "Running with server %s (%s) and client %s (%s)",
+                    server,
+                    self._implementations[server],
+                    client,
+                    self._implementations[client],
+                )
+                if not (
+                    self._check_impl_is_compliant(server)
+                    and self._check_impl_is_compliant(client)
+                ):
+                    logging.info("Not compliant, skipping")
+                    continue
 
-        # run the test cases
-        for testcase in self._tests:
-          status = self._run_testcase(server, client, testcase)
-          self.test_results[server][client][testcase] = status
+                # run the test cases
+                for testcase in self._tests:
+                    status = self._run_testcase(server, client, testcase)
+                    self.test_results[server][client][testcase] = status
 
-        # run the measurements
-        for measurement in self._measurements:
-          res = self._run_measurement(server, client, measurement)
-          self.measurement_results[server][client][measurement] = res
+                # run the measurements
+                for measurement in self._measurements:
+                    res = self._run_measurement(server, client, measurement)
+                    self.measurement_results[server][client][measurement] = res
 
-    self._print_results()
-    self._export_results()
+        self._print_results()
+        self._export_results()

--- a/pull.py
+++ b/pull.py
@@ -1,4 +1,5 @@
 import os
+
 from implementations import IMPLEMENTATIONS
 
 print("Pulling the simulator...")
@@ -8,5 +9,5 @@ print("\nPulling the iperf endpoint...")
 os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
 
 for name, value in IMPLEMENTATIONS.items():
-  print("\nPulling " + name + "...")
-  os.system("docker pull " + value["url"])
+    print("\nPulling " + name + "...")
+    os.system("docker pull " + value["url"])

--- a/run.py
+++ b/run.py
@@ -1,90 +1,118 @@
 #!/usr/bin/env python3
 
-import argparse, copy, logging, sys
+import argparse
+import logging
+import sys
 from typing import List
 
-from interop import InteropRunner
 import testcases
-from testcases import TESTCASES, MEASUREMENTS
 from implementations import IMPLEMENTATIONS
+from interop import InteropRunner
+from testcases import MEASUREMENTS, TESTCASES
+
 
 def get_args():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('-d', '--debug', action='store_const',
-                      const=True, default=False,
-                      help='turn on debug logs')
-  parser.add_argument("-s", "--server", help="server implementations (comma-separated)")
-  parser.add_argument("-c", "--client", help="client implementations (comma-separated)")
-  parser.add_argument("-t", "--test", help="test cases (comma-separatated)")
-  parser.add_argument("-m", "--measurement", help="measurements (comma-separatated)")
-  parser.add_argument("-r", "--replace", help="replace path of implementation. Example: -r myquicimpl=dockertagname")
-  parser.add_argument("-j", "--json", help="output the matrix to file in json format")
-  return parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_const",
+        const=True,
+        default=False,
+        help="turn on debug logs",
+    )
+    parser.add_argument(
+        "-s", "--server", help="server implementations (comma-separated)"
+    )
+    parser.add_argument(
+        "-c", "--client", help="client implementations (comma-separated)"
+    )
+    parser.add_argument("-t", "--test", help="test cases (comma-separatated)")
+    parser.add_argument("-m", "--measurement", help="measurements (comma-separatated)")
+    parser.add_argument(
+        "-r",
+        "--replace",
+        help="replace path of implementation. Example: -r myquicimpl=dockertagname",
+    )
+    parser.add_argument("-j", "--json", help="output the matrix to file in json format")
+    return parser.parse_args()
 
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 console = logging.StreamHandler(stream=sys.stderr)
 if get_args().debug:
-  console.setLevel(logging.DEBUG)
+    console.setLevel(logging.DEBUG)
 else:
-  console.setLevel(logging.INFO)
+    console.setLevel(logging.INFO)
 logger.addHandler(console)
 
-implementations={ name:value["url"] for name, value in IMPLEMENTATIONS.items() }
-client_implementations = [ name for name, value in IMPLEMENTATIONS.items() if value["role"] == 0 or value["role"] == 2 ]
-server_implementations = [ name for name, value in IMPLEMENTATIONS.items() if value["role"] == 1 or value["role"] == 2 ]
+implementations = {name: value["url"] for name, value in IMPLEMENTATIONS.items()}
+client_implementations = [
+    name
+    for name, value in IMPLEMENTATIONS.items()
+    if value["role"] == 0 or value["role"] == 2
+]
+server_implementations = [
+    name
+    for name, value in IMPLEMENTATIONS.items()
+    if value["role"] == 1 or value["role"] == 2
+]
 
 replace_arg = get_args().replace
 if replace_arg:
-  for s in replace_arg.split(","):
-    pair = s.split("=")
-    if len(pair) != 2:
-      sys.exit("Invalid format for replace")
-    name, image = pair[0], pair[1]
-    if name not in IMPLEMENTATIONS:
-      sys.exit("Implementation " + name + " not found.")
-    implementations[name] = image
+    for s in replace_arg.split(","):
+        pair = s.split("=")
+        if len(pair) != 2:
+            sys.exit("Invalid format for replace")
+        name, image = pair[0], pair[1]
+        if name not in IMPLEMENTATIONS:
+            sys.exit("Implementation " + name + " not found.")
+        implementations[name] = image
+
 
 def get_impls(arg, availableImpls, role) -> List[str]:
-  if not arg:
-    return availableImpls
-  impls = []
-  for s in arg.split(","):
-    if s not in availableImpls:
-      sys.exit(role + " implementation " + s + " not found.")
-    impls.append(s)
-  return impls
+    if not arg:
+        return availableImpls
+    impls = []
+    for s in arg.split(","):
+        if s not in availableImpls:
+            sys.exit(role + " implementation " + s + " not found.")
+        impls.append(s)
+    return impls
+
 
 def get_tests(arg) -> List[testcases.TestCase]:
-  if arg is None:
-    return TESTCASES
-  if len(arg) is 0:
-    return []
-  tests = []
-  for t in arg.split(","):
-    if t not in [ tc.name() for tc in TESTCASES ]:
-      sys.exit("Test case " + t + " not found.")
-    tests += [ tc for tc in TESTCASES if tc.name()==t ]
-  return tests
+    if arg is None:
+        return TESTCASES
+    elif not arg:
+        return []
+    tests = []
+    for t in arg.split(","):
+        if t not in [tc.name() for tc in TESTCASES]:
+            sys.exit("Test case " + t + " not found.")
+        tests += [tc for tc in TESTCASES if tc.name() == t]
+    return tests
+
 
 def get_measurements(arg) -> List[testcases.TestCase]:
-  if arg is None:
-    return MEASUREMENTS
-  if len(arg) is 0:
-    return []
-  tests = []
-  for t in arg.split(","):
-    if t not in [ tc.name() for tc in MEASUREMENTS ]:
-      sys.exit("Measurement " + t + " not found.")
-    tests += [ tc for tc in MEASUREMENTS if tc.name()==t ]
-  return tests
+    if arg is None:
+        return MEASUREMENTS
+    elif not arg:
+        return []
+    tests = []
+    for t in arg.split(","):
+        if t not in [tc.name() for tc in MEASUREMENTS]:
+            sys.exit("Measurement " + t + " not found.")
+        tests += [tc for tc in MEASUREMENTS if tc.name() == t]
+    return tests
+
 
 InteropRunner(
-  implementations=implementations,
-  servers=get_impls(get_args().server, server_implementations, "Server"),
-  clients=get_impls(get_args().client, client_implementations, "Client"),
-  tests=get_tests(get_args().test),
-  measurements=get_measurements(get_args().measurement),
-  output=get_args().json,
+    implementations=implementations,
+    servers=get_impls(get_args().server, server_implementations, "Server"),
+    clients=get_impls(get_args().client, client_implementations, "Client"),
+    tests=get_tests(get_args().test),
+    measurements=get_measurements(get_args().measurement),
+    output=get_args().json,
 ).run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore=E501,W503

--- a/testcases.py
+++ b/testcases.py
@@ -1,552 +1,591 @@
-import abc, filecmp, os, string, tempfile, random, logging, sys
-from Crypto.Cipher import AES
+import abc
+import filecmp
+import logging
+import os
+import random
+import string
+import tempfile
 from datetime import timedelta
+from trace import Direction, TraceAnalyzer
 from typing import List
 
-from trace import TraceAnalyzer, Direction
+from Crypto.Cipher import AES
 
-KB = 1<<10
-MB = 1<<20
+KB = 1 << 10
+MB = 1 << 20
 
-QUIC_VERSION="0xff000019" # draft-25
+QUIC_VERSION = "0xff000019"  # draft-25
+
 
 def random_string(length: int):
-  """Generate a random string of fixed length """
-  letters = string.ascii_lowercase
-  return ''.join(random.choice(letters) for i in range(length))
+    """Generate a random string of fixed length """
+    letters = string.ascii_lowercase
+    return "".join(random.choice(letters) for i in range(length))
+
 
 class TestCase(abc.ABC):
-  _files = []
-  _www_dir = None
-  _download_dir = None
-  _sim_log_dir = None
+    _files = []
+    _www_dir = None
+    _download_dir = None
+    _sim_log_dir = None
 
-  def __init__(self, sim_log_dir: tempfile.TemporaryDirectory, client_keylog_file: str):
-    self._client_keylog_file = client_keylog_file
-    self._files = []
-    self._sim_log_dir = sim_log_dir
+    def __init__(
+        self, sim_log_dir: tempfile.TemporaryDirectory, client_keylog_file: str
+    ):
+        self._client_keylog_file = client_keylog_file
+        self._files = []
+        self._sim_log_dir = sim_log_dir
 
-  @abc.abstractmethod
-  def name(self):
-    pass
+    @abc.abstractmethod
+    def name(self):
+        pass
 
-  def __str__(self):
-    return self.name()
+    def __str__(self):
+        return self.name()
 
-  def testname(self):
-    """ The name of testcase presented to the endpoint Docker images"""
-    return self.name()
+    def testname(self):
+        """ The name of testcase presented to the endpoint Docker images"""
+        return self.name()
 
-  @staticmethod
-  def scenario() -> str:
-    """ Scenario for the ns3 simulator """
-    return "simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25"
+    @staticmethod
+    def scenario() -> str:
+        """ Scenario for the ns3 simulator """
+        return "simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25"
 
-  @staticmethod
-  def timeout() -> int:
-    """ timeout in s """
-    return 60
+    @staticmethod
+    def timeout() -> int:
+        """ timeout in s """
+        return 60
 
-  @staticmethod
-  def additional_envs() -> List[str]:
-    return [ "" ]
+    @staticmethod
+    def additional_envs() -> List[str]:
+        return [""]
 
-  @staticmethod
-  def additional_containers() -> List[str]:
-    return [ "" ]
+    @staticmethod
+    def additional_containers() -> List[str]:
+        return [""]
 
-  def www_dir(self):
-    if not self._www_dir:
-      self._www_dir = tempfile.TemporaryDirectory(dir = "/tmp", prefix = "www_")
-    return self._www_dir.name + "/"
-  
-  def download_dir(self):
-    if not self._download_dir:
-      self._download_dir = tempfile.TemporaryDirectory(dir = "/tmp", prefix = "download_")
-    return self._download_dir.name + "/"
+    def www_dir(self):
+        if not self._www_dir:
+            self._www_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="www_")
+        return self._www_dir.name + "/"
 
-  def _client_trace(self):
-    return TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap", self._client_keylog_file)
+    def download_dir(self):
+        if not self._download_dir:
+            self._download_dir = tempfile.TemporaryDirectory(
+                dir="/tmp", prefix="download_"
+            )
+        return self._download_dir.name + "/"
 
-  # see https://www.stefanocappellini.it/generate-pseudorandom-bytes-with-python/ for benchmarks
-  def _generate_random_file(self, size: int) -> str:
-    filename = random_string(10)
-    enc = AES.new(os.urandom(32), AES.MODE_OFB, b'a' * 16)
-    f = open(self.www_dir() + filename, "wb")
-    f.write(enc.encrypt(b' ' * size))
-    f.close()
-    logging.debug("Generated random file: %s of size: %d", filename, size)
-    return filename
+    def _client_trace(self):
+        return TraceAnalyzer(
+            self._sim_log_dir.name + "/trace_node_left.pcap", self._client_keylog_file
+        )
 
-  def _retry_sent(self) -> bool:
-    return len(self._client_trace().get_retry()) > 0
+    # see https://www.stefanocappellini.it/generate-pseudorandom-bytes-with-python/ for benchmarks
+    def _generate_random_file(self, size: int) -> str:
+        filename = random_string(10)
+        enc = AES.new(os.urandom(32), AES.MODE_OFB, b"a" * 16)
+        f = open(self.www_dir() + filename, "wb")
+        f.write(enc.encrypt(b" " * size))
+        f.close()
+        logging.debug("Generated random file: %s of size: %d", filename, size)
+        return filename
 
-  def _check_version_and_files(self):
-    versions = self._get_versions()
-    if len(versions) != 1:
-      logging.info("Expected exactly one version. Got %s", versions)
-      return False
-    if QUIC_VERSION not in versions:
-      logging.info("Wrong version. Expected %s, got %s", QUIC_VERSION, versions)
-      return False
+    def _retry_sent(self) -> bool:
+        return len(self._client_trace().get_retry()) > 0
 
-    if len(self._files) == 0:
-      raise Exception("No test files generated.")
-    num_files = len([ n for n in os.listdir(self.download_dir()) if os.path.isfile(os.path.join(self.download_dir(), n)) ])
-    if num_files != len(self._files):
-      logging.info("Downloaded the wrong number of files. Got %d, expected %d.", num_files, len(self._files))
-      return False
-    for f in self._files:
-      fp = self.download_dir() + f
-      if not os.path.isfile(fp):
-        logging.info("File %s does not exist.", fp)
-        return False
-      try:
-        if not filecmp.cmp(self.www_dir() + f, fp, shallow=False):
-          logging.info("File contents of %s do not match.", fp)
-          return False
-      except Exception as exception:
-        logging.info("Could not compare files %s and %s: %s", self.www_dir() + f, fp, exception)
-        return False
-    logging.debug("Check of downloaded files succeeded.")
-    return True
+    def _check_version_and_files(self):
+        versions = self._get_versions()
+        if len(versions) != 1:
+            logging.info("Expected exactly one version. Got %s", versions)
+            return False
+        if QUIC_VERSION not in versions:
+            logging.info("Wrong version. Expected %s, got %s", QUIC_VERSION, versions)
+            return False
 
-  def _count_handshakes(self) -> int:
-    """ Count the number of QUIC handshakes """
-    tr = self._client_trace()
-    # Determine the number of handshakes by looking at Initial packets.
-    # This is easier, since the SCID of Initial packets doesn't changes.
-    return len(set([ p.scid for p in tr.get_initial(Direction.FROM_SERVER) ]))
+        if len(self._files) == 0:
+            raise Exception("No test files generated.")
+        num_files = len(
+            [
+                n
+                for n in os.listdir(self.download_dir())
+                if os.path.isfile(os.path.join(self.download_dir(), n))
+            ]
+        )
+        if num_files != len(self._files):
+            logging.info(
+                "Downloaded the wrong number of files. Got %d, expected %d.",
+                num_files,
+                len(self._files),
+            )
+            return False
+        for f in self._files:
+            fp = self.download_dir() + f
+            if not os.path.isfile(fp):
+                logging.info("File %s does not exist.", fp)
+                return False
+            try:
+                if not filecmp.cmp(self.www_dir() + f, fp, shallow=False):
+                    logging.info("File contents of %s do not match.", fp)
+                    return False
+            except Exception as exception:
+                logging.info(
+                    "Could not compare files %s and %s: %s",
+                    self.www_dir() + f,
+                    fp,
+                    exception,
+                )
+                return False
+        logging.debug("Check of downloaded files succeeded.")
+        return True
 
-  def _get_versions(self) -> set:
-    """ Get the QUIC versions """
-    tr = TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap")
-    return set([ p.version for p in tr.get_initial(Direction.FROM_SERVER) ])
+    def _count_handshakes(self) -> int:
+        """ Count the number of QUIC handshakes """
+        tr = self._client_trace()
+        # Determine the number of handshakes by looking at Initial packets.
+        # This is easier, since the SCID of Initial packets doesn't changes.
+        return len(set([p.scid for p in tr.get_initial(Direction.FROM_SERVER)]))
 
-  def cleanup(self):
-    if self._www_dir:
-      self._www_dir.cleanup()
-      self._www_dir = None
-    if self._download_dir:
-      self._download_dir.cleanup()
-      self._download_dir = None
+    def _get_versions(self) -> set:
+        """ Get the QUIC versions """
+        tr = TraceAnalyzer(self._sim_log_dir.name + "/trace_node_left.pcap")
+        return set([p.version for p in tr.get_initial(Direction.FROM_SERVER)])
 
-  @abc.abstractmethod
-  def get_paths(self):
-    pass
+    def cleanup(self):
+        if self._www_dir:
+            self._www_dir.cleanup()
+            self._www_dir = None
+        if self._download_dir:
+            self._download_dir.cleanup()
+            self._download_dir = None
 
-  @abc.abstractmethod
-  def check(self) -> bool:
-    pass
+    @abc.abstractmethod
+    def get_paths(self):
+        pass
+
+    @abc.abstractmethod
+    def check(self) -> bool:
+        pass
 
 
 class Measurement(TestCase):
-  @abc.abstractmethod
-  def result(self) -> float:
-    pass
+    @abc.abstractmethod
+    def result(self) -> float:
+        pass
 
-  @staticmethod
-  @abc.abstractmethod
-  def unit() -> str:
-    pass
+    @staticmethod
+    @abc.abstractmethod
+    def unit() -> str:
+        pass
 
-  @staticmethod
-  @abc.abstractmethod
-  def repetitions() -> int:
-    pass
+    @staticmethod
+    @abc.abstractmethod
+    def repetitions() -> int:
+        pass
 
 
 class TestCaseVersionNegotiation(TestCase):
-  @staticmethod
-  def name():
-    return "versionnegotiation"
-  
-  @staticmethod
-  def abbreviation():
-    return "V"
+    @staticmethod
+    def name():
+        return "versionnegotiation"
 
-  def get_paths(self):
-    return [ "" ]
-  
-  def check(self):
-    tr = self._client_trace()
-    initials = tr.get_initial(Direction.FROM_CLIENT)
-    dcid = ""
-    for p in initials:
-      dcid = p.dcid
-      break
-    if dcid is "":
-      logging.info("Didn't find an Initial / a DCID.")
-      return False
-    vnps = tr.get_vnp()
-    for p in vnps:
-      if p.scid == dcid:
-        return True
-    logging.info("Didn't find a Version Negotiation Packet with matching SCID.")
-    return False
+    @staticmethod
+    def abbreviation():
+        return "V"
+
+    def get_paths(self):
+        return [""]
+
+    def check(self):
+        tr = self._client_trace()
+        initials = tr.get_initial(Direction.FROM_CLIENT)
+        dcid = ""
+        for p in initials:
+            dcid = p.dcid
+            break
+        if dcid == "":
+            logging.info("Didn't find an Initial / a DCID.")
+            return False
+        vnps = tr.get_vnp()
+        for p in vnps:
+            if p.scid == dcid:
+                return True
+        logging.info("Didn't find a Version Negotiation Packet with matching SCID.")
+        return False
 
 
 class TestCaseHandshake(TestCase):
-  @staticmethod
-  def name():
-    return "handshake"
+    @staticmethod
+    def name():
+        return "handshake"
 
-  @staticmethod
-  def abbreviation():
-    return "H"
+    @staticmethod
+    def abbreviation():
+        return "H"
 
-  def get_paths(self):
-    self._files = [ self._generate_random_file(1*KB) ]
-    return self._files
+    def get_paths(self):
+        self._files = [self._generate_random_file(1 * KB)]
+        return self._files
 
-  def check(self):
-    if not self._check_version_and_files():
-      return False
-    if self._retry_sent():
-      logging.info("Didn't expect a Retry to be sent.")
-      return False
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    return True
+    def check(self):
+        if not self._check_version_and_files():
+            return False
+        if self._retry_sent():
+            logging.info("Didn't expect a Retry to be sent.")
+            return False
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        return True
 
 
 class TestCaseTransfer(TestCase):
-  @staticmethod
-  def name():
-    return "transfer"
+    @staticmethod
+    def name():
+        return "transfer"
 
-  @staticmethod
-  def abbreviation():
-    return "DC"
+    @staticmethod
+    def abbreviation():
+        return "DC"
 
-  def get_paths(self):
-    self._files = [ 
-      self._generate_random_file(2*MB),
-      self._generate_random_file(3*MB),
-      self._generate_random_file(5*MB),
-    ]
-    return self._files
+    def get_paths(self):
+        self._files = [
+            self._generate_random_file(2 * MB),
+            self._generate_random_file(3 * MB),
+            self._generate_random_file(5 * MB),
+        ]
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        return self._check_version_and_files()
 
 
 class TestCaseMultiplexing(TestCase):
-  @staticmethod
-  def name():
-    return "multiplexing"
+    @staticmethod
+    def name():
+        return "multiplexing"
 
-  @staticmethod
-  def testname():
-    return "transfer"
+    @staticmethod
+    def testname():
+        return "transfer"
 
-  @staticmethod
-  def abbreviation():
-    return "M"
+    @staticmethod
+    def abbreviation():
+        return "M"
 
-  def get_paths(self):
-    for _ in range(1, 2000):
-      self._files.append(self._generate_random_file(32))
-    return self._files
+    def get_paths(self):
+        for _ in range(1, 2000):
+            self._files.append(self._generate_random_file(32))
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        return self._check_version_and_files()
 
 
 class TestCaseRetry(TestCase):
-  @staticmethod
-  def name():
-    return "retry"
+    @staticmethod
+    def name():
+        return "retry"
 
-  @staticmethod
-  def abbreviation():
-    return "S"
+    @staticmethod
+    def abbreviation():
+        return "S"
 
-  def get_paths(self):
-    self._files = [ self._generate_random_file(10*KB), ]
-    return self._files
+    def get_paths(self):
+        self._files = [
+            self._generate_random_file(10 * KB),
+        ]
+        return self._files
 
-  def _check_trace(self) -> bool:
-    # check that (at least) one Retry packet was actually sent
-    tr = self._client_trace()
-    tokens = []
-    retries = tr.get_retry(Direction.FROM_SERVER)
-    for p in retries:
-      tokens += [ p.retry_token.replace(":", "") ]
-    if len(tokens) == 0:
-      logging.info("Didn't find any Retry packets.")
-      return False
-    
-    # check that an Initial packet uses a token sent in the Retry packet(s)
-    initials = tr.get_initial(Direction.FROM_CLIENT)
-    for p in initials:
-      if p.token_length == "0":
-        continue
-      token = p.token.replace(":", "")
-      if token in tokens:
-        logging.debug("Check of Retry succeeded. Token used: %s", token)
-        return True
-    logging.info("Didn't find any Initial packet using a Retry token.")
-    return False
+    def _check_trace(self) -> bool:
+        # check that (at least) one Retry packet was actually sent
+        tr = self._client_trace()
+        tokens = []
+        retries = tr.get_retry(Direction.FROM_SERVER)
+        for p in retries:
+            tokens += [p.retry_token.replace(":", "")]
+        if len(tokens) == 0:
+            logging.info("Didn't find any Retry packets.")
+            return False
 
-  def check(self) -> bool:
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    if not self._check_version_and_files():
-      return False
-    return self._check_trace()
-    
+        # check that an Initial packet uses a token sent in the Retry packet(s)
+        initials = tr.get_initial(Direction.FROM_CLIENT)
+        for p in initials:
+            if p.token_length == "0":
+                continue
+            token = p.token.replace(":", "")
+            if token in tokens:
+                logging.debug("Check of Retry succeeded. Token used: %s", token)
+                return True
+        logging.info("Didn't find any Initial packet using a Retry token.")
+        return False
+
+    def check(self) -> bool:
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        if not self._check_version_and_files():
+            return False
+        return self._check_trace()
+
 
 class TestCaseResumption(TestCase):
-  @staticmethod
-  def name():
-    return "resumption"
+    @staticmethod
+    def name():
+        return "resumption"
 
-  @staticmethod
-  def abbreviation():
-    return "R"
+    @staticmethod
+    def abbreviation():
+        return "R"
 
-  def get_paths(self):
-    self._files = [ 
-      self._generate_random_file(5*KB),
-      self._generate_random_file(10*KB),
-    ]
-    return self._files
+    def get_paths(self):
+        self._files = [
+            self._generate_random_file(5 * KB),
+            self._generate_random_file(10 * KB),
+        ]
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 2:
-      logging.info("Expected exactly 2 handshake. Got: %d", num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 2:
+            logging.info("Expected exactly 2 handshake. Got: %d", num_handshakes)
+            return False
+        return self._check_version_and_files()
 
 
 class TestCaseHTTP3(TestCase):
-  @staticmethod
-  def name():
-    return "http3"
+    @staticmethod
+    def name():
+        return "http3"
 
-  @staticmethod
-  def abbreviation():
-    return "3"
+    @staticmethod
+    def abbreviation():
+        return "3"
 
-  def get_paths(self):
-    self._files = [ 
-      self._generate_random_file(5*KB),
-      self._generate_random_file(10*KB),
-      self._generate_random_file(500*KB),
-    ]
-    return self._files
+    def get_paths(self):
+        self._files = [
+            self._generate_random_file(5 * KB),
+            self._generate_random_file(10 * KB),
+            self._generate_random_file(500 * KB),
+        ]
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        return self._check_version_and_files()
 
 
 class TestCaseBlackhole(TestCase):
-  @staticmethod
-  def name():
-    return "blackhole"
+    @staticmethod
+    def name():
+        return "blackhole"
 
-  @staticmethod
-  def testname():
-    return "transfer"
+    @staticmethod
+    def testname():
+        return "transfer"
 
-  @staticmethod
-  def abbreviation():
-    return "B"
+    @staticmethod
+    def abbreviation():
+        return "B"
 
-  @staticmethod
-  def scenario() -> str:
-    """ Scenario for the ns3 simulator """
-    return "blackhole --delay=15ms --bandwidth=10Mbps --queue=25 --on=5s --off=2s"
+    @staticmethod
+    def scenario() -> str:
+        """ Scenario for the ns3 simulator """
+        return "blackhole --delay=15ms --bandwidth=10Mbps --queue=25 --on=5s --off=2s"
 
-  def get_paths(self):
-    self._files = [ self._generate_random_file(10*MB) ]
-    return self._files
+    def get_paths(self):
+        self._files = [self._generate_random_file(10 * MB)]
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        return self._check_version_and_files()
 
 
 class TestCaseHandshakeLoss(TestCase):
-  _num_runs = 50
+    _num_runs = 50
 
-  @staticmethod
-  def name():
-    return "handshakeloss"
+    @staticmethod
+    def name():
+        return "handshakeloss"
 
-  @staticmethod
-  def testname():
-    return "multiconnect"
+    @staticmethod
+    def testname():
+        return "multiconnect"
 
-  @staticmethod
-  def abbreviation():
-    return "L1"
+    @staticmethod
+    def abbreviation():
+        return "L1"
 
-  @staticmethod
-  def timeout() -> int:
-    return 300
+    @staticmethod
+    def timeout() -> int:
+        return 300
 
-  @staticmethod
-  def scenario() -> str:
-    """ Scenario for the ns3 simulator """
-    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_server=30 --rate_to_client=30"
+    @staticmethod
+    def scenario() -> str:
+        """ Scenario for the ns3 simulator """
+        return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_server=30 --rate_to_client=30"
 
-  def get_paths(self):
-    for _ in range(self._num_runs):
-      self._files.append(self._generate_random_file(1*KB))
-    return self._files
+    def get_paths(self):
+        for _ in range(self._num_runs):
+            self._files.append(self._generate_random_file(1 * KB))
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != self._num_runs:
-      logging.info("Expected %d handshakes. Got: %d", self._num_runs, num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != self._num_runs:
+            logging.info(
+                "Expected %d handshakes. Got: %d", self._num_runs, num_handshakes
+            )
+            return False
+        return self._check_version_and_files()
+
 
 class TestCaseTransferLoss(TestCase):
-  @staticmethod
-  def name():
-    return "transferloss"
+    @staticmethod
+    def name():
+        return "transferloss"
 
-  @staticmethod
-  def testname():
-    return "transfer"
+    @staticmethod
+    def testname():
+        return "transfer"
 
-  @staticmethod
-  def abbreviation():
-    return "L2"
+    @staticmethod
+    def abbreviation():
+        return "L2"
 
-  @staticmethod
-  def scenario() -> str:
-    """ Scenario for the ns3 simulator """
-    return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_server=2 --rate_to_client=2"
+    @staticmethod
+    def scenario() -> str:
+        """ Scenario for the ns3 simulator """
+        return "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_server=2 --rate_to_client=2"
 
-  def get_paths(self):
-    # At a packet loss rate of 2% and a MTU of 1500 bytes, we can expect 27 dropped packets.
-    self._files = [ self._generate_random_file(2*MB) ]
-    return self._files
+    def get_paths(self):
+        # At a packet loss rate of 2% and a MTU of 1500 bytes, we can expect 27 dropped packets.
+        self._files = [self._generate_random_file(2 * MB)]
+        return self._files
 
-  def check(self):
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    return self._check_version_and_files()
+    def check(self):
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        return self._check_version_and_files()
 
 
 class MeasurementGoodput(Measurement):
-  FILESIZE = 10*MB
-  _result = 0.0
+    FILESIZE = 10 * MB
+    _result = 0.0
 
-  @staticmethod
-  def name():
-    return "goodput"
+    @staticmethod
+    def name():
+        return "goodput"
 
-  @staticmethod
-  def unit() -> str:
-    return "kbps"
+    @staticmethod
+    def unit() -> str:
+        return "kbps"
 
-  @staticmethod
-  def testname():
-    return "transfer"
+    @staticmethod
+    def testname():
+        return "transfer"
 
-  @staticmethod
-  def abbreviation():
-    return "G"
+    @staticmethod
+    def abbreviation():
+        return "G"
 
-  @staticmethod
-  def repetitions() -> int:
-    return 5
+    @staticmethod
+    def repetitions() -> int:
+        return 5
 
-  def get_paths(self):
-    self._files = [ self._generate_random_file(self.FILESIZE) ]
-    return self._files
+    def get_paths(self):
+        self._files = [self._generate_random_file(self.FILESIZE)]
+        return self._files
 
-  def check(self) -> bool:
-    num_handshakes = self._count_handshakes()
-    if num_handshakes != 1:
-      logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
-      return False
-    if not self._check_version_and_files():
-      return False
+    def check(self) -> bool:
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return False
+        if not self._check_version_and_files():
+            return False
 
-    packets = self._client_trace().get_1rtt(Direction.FROM_SERVER)
-    first, last = 0, 0
-    for p in packets:
-      if (first == 0):
-        first = p.sniff_time
-      last = p.sniff_time
+        packets = self._client_trace().get_1rtt(Direction.FROM_SERVER)
+        first, last = 0, 0
+        for p in packets:
+            if first == 0:
+                first = p.sniff_time
+            last = p.sniff_time
 
-    if (last - first == 0):
-      return False
-    time = (last - first) / timedelta(milliseconds = 1)
-    goodput = (8 * self.FILESIZE) / time
-    logging.debug("Transfering %d MB took %d ms. Goodput: %d kbps", self.FILESIZE/MB, time, goodput)
-    self._result = goodput
-    return True
+        if last - first == 0:
+            return False
+        time = (last - first) / timedelta(milliseconds=1)
+        goodput = (8 * self.FILESIZE) / time
+        logging.debug(
+            "Transfering %d MB took %d ms. Goodput: %d kbps",
+            self.FILESIZE / MB,
+            time,
+            goodput,
+        )
+        self._result = goodput
+        return True
 
-  def result(self) -> float:
-    return self._result
+    def result(self) -> float:
+        return self._result
 
 
 class MeasurementCrossTraffic(MeasurementGoodput):
-  FILESIZE=25*MB
+    FILESIZE = 25 * MB
 
-  @staticmethod
-  def name():
-    return "crosstraffic"
+    @staticmethod
+    def name():
+        return "crosstraffic"
 
-  @staticmethod
-  def abbreviation():
-    return "C"
+    @staticmethod
+    def abbreviation():
+        return "C"
 
-  @staticmethod
-  def timeout() -> int:
-    return 180
-  
-  @staticmethod
-  def additional_envs() -> List[str]:
-    return [ "IPERF_CONGESTION=cubic" ]
+    @staticmethod
+    def timeout() -> int:
+        return 180
 
-  @staticmethod
-  def additional_containers() -> List[str]:
-    return [ "iperf_server", "iperf_client" ]
+    @staticmethod
+    def additional_envs() -> List[str]:
+        return ["IPERF_CONGESTION=cubic"]
+
+    @staticmethod
+    def additional_containers() -> List[str]:
+        return ["iperf_server", "iperf_client"]
 
 
-TESTCASES = [ 
-  TestCaseHandshake,
-  TestCaseTransfer,
-  TestCaseMultiplexing,
-  TestCaseRetry,
-  TestCaseResumption,
-  TestCaseHTTP3,
-  TestCaseBlackhole,
-  TestCaseHandshakeLoss,
-  TestCaseTransferLoss,
+TESTCASES = [
+    TestCaseHandshake,
+    TestCaseTransfer,
+    TestCaseMultiplexing,
+    TestCaseRetry,
+    TestCaseResumption,
+    TestCaseHTTP3,
+    TestCaseBlackhole,
+    TestCaseHandshakeLoss,
+    TestCaseTransferLoss,
 ]
 
 MEASUREMENTS = [
-  MeasurementGoodput,
-  MeasurementCrossTraffic,
+    MeasurementGoodput,
+    MeasurementCrossTraffic,
 ]

--- a/trace.py
+++ b/trace.py
@@ -3,78 +3,102 @@ from typing import List, Optional
 
 import pyshark
 
+
 class Direction(Enum):
-  ALL = 0
-  FROM_CLIENT = 1
-  FROM_SERVER = 2
+    ALL = 0
+    FROM_CLIENT = 1
+    FROM_SERVER = 2
+
 
 class TraceAnalyzer:
-  _filename = ""
+    _filename = ""
 
-  def __init__(self, filename: str, keylog_file: Optional[str] = None):
-    self._filename = filename
-    self._keylog_file = keylog_file
+    def __init__(self, filename: str, keylog_file: Optional[str] = None):
+        self._filename = filename
+        self._keylog_file = keylog_file
 
-  def _get_direction_filter(self, d: Direction) -> str:
-    f = "(quic && !icmp) && "
-    if d == Direction.FROM_CLIENT:
-      return f + "ip.src==193.167.0.100 && "
-    elif d == Direction.FROM_SERVER:
-      return f + "ip.src==193.167.100.100 && "
-    else:
-      return f
+    def _get_direction_filter(self, d: Direction) -> str:
+        f = "(quic && !icmp) && "
+        if d == Direction.FROM_CLIENT:
+            return f + "ip.src==193.167.0.100 && "
+        elif d == Direction.FROM_SERVER:
+            return f + "ip.src==193.167.100.100 && "
+        else:
+            return f
 
-  def _get_packets(self, f: str) -> List:
-    override_prefs = {}
-    if self._keylog_file is not None:
-        override_prefs["ssl.keylog_file"] = self._keylog_file
-    cap = pyshark.FileCapture(self._filename, display_filter=f, override_prefs=override_prefs)
-    packets = []
-    # If the pcap has been cut short in the middle of the packet, pyshark will crash.
-    # See https://github.com/KimiNewt/pyshark/issues/390.
-    try:
-      for p in cap:
-        packets.append(p)
-      cap.close()
-    except Exception as e:
-      print(e)
-    return packets
+    def _get_packets(self, f: str) -> List:
+        override_prefs = {}
+        if self._keylog_file is not None:
+            override_prefs["ssl.keylog_file"] = self._keylog_file
+        cap = pyshark.FileCapture(
+            self._filename, display_filter=f, override_prefs=override_prefs
+        )
+        packets = []
+        # If the pcap has been cut short in the middle of the packet, pyshark will crash.
+        # See https://github.com/KimiNewt/pyshark/issues/390.
+        try:
+            for p in cap:
+                packets.append(p)
+            cap.close()
+        except Exception as e:
+            print(e)
+        return packets
 
-  def get_1rtt(self, direction: Direction = Direction.ALL) -> List:
-    """ Get all QUIC packets, one or both directions. """
-    packets = []
-    for packet in self._get_packets(self._get_direction_filter(direction) + "quic.header_form==0"):
-      for layer in packet.layers:
-        if layer.layer_name == "quic" and not hasattr(layer, "long_packet_type"):
-          layer.sniff_time = packet.sniff_time
-          packets.append(layer)
-    return packets
-    
-  def get_vnp(self, direction: Direction = Direction.ALL) -> List:
-    return self._get_packets(self._get_direction_filter(direction) + "quic.version==0")
+    def get_1rtt(self, direction: Direction = Direction.ALL) -> List:
+        """ Get all QUIC packets, one or both directions. """
+        packets = []
+        for packet in self._get_packets(
+            self._get_direction_filter(direction) + "quic.header_form==0"
+        ):
+            for layer in packet.layers:
+                if layer.layer_name == "quic" and not hasattr(
+                    layer, "long_packet_type"
+                ):
+                    layer.sniff_time = packet.sniff_time
+                    packets.append(layer)
+        return packets
 
-  def get_retry(self, direction: Direction = Direction.ALL) -> List:
-    packets = []
-    for packet in self._get_packets(self._get_direction_filter(direction) + "quic.long.packet_type==Retry"):
-      for layer in packet.layers:
-        if layer.layer_name == "quic":
-          packets.append(layer)
-    return packets
+    def get_vnp(self, direction: Direction = Direction.ALL) -> List:
+        return self._get_packets(
+            self._get_direction_filter(direction) + "quic.version==0"
+        )
 
-  def get_initial(self, direction: Direction = Direction.ALL) -> List:
-    """ Get all Initial packets. """
-    packets = []
-    for packet in self._get_packets(self._get_direction_filter(direction) + "quic.long.packet_type"):
-      for layer in packet.layers:
-        if layer.layer_name == "quic" and hasattr(layer, "long_packet_type") and layer.long_packet_type == "0":
-          packets.append(layer)
-    return packets
+    def get_retry(self, direction: Direction = Direction.ALL) -> List:
+        packets = []
+        for packet in self._get_packets(
+            self._get_direction_filter(direction) + "quic.long.packet_type==Retry"
+        ):
+            for layer in packet.layers:
+                if layer.layer_name == "quic":
+                    packets.append(layer)
+        return packets
 
-  def get_handshake(self, direction: Direction = Direction.ALL) -> List:
-    """ Get all Handshake packets. """
-    packets = []
-    for packet in self._get_packets(self._get_direction_filter(direction) + "quic.long.packet_type"):
-      for layer in packet.layers:
-        if layer.layer_name == "quic" and hasattr(layer, "long_packet_type") and layer.long_packet_type == "2":
-          packets.append(layer)
-    return packets
+    def get_initial(self, direction: Direction = Direction.ALL) -> List:
+        """ Get all Initial packets. """
+        packets = []
+        for packet in self._get_packets(
+            self._get_direction_filter(direction) + "quic.long.packet_type"
+        ):
+            for layer in packet.layers:
+                if (
+                    layer.layer_name == "quic"
+                    and hasattr(layer, "long_packet_type")
+                    and layer.long_packet_type == "0"
+                ):
+                    packets.append(layer)
+        return packets
+
+    def get_handshake(self, direction: Direction = Direction.ALL) -> List:
+        """ Get all Handshake packets. """
+        packets = []
+        for packet in self._get_packets(
+            self._get_direction_filter(direction) + "quic.long.packet_type"
+        ):
+            for layer in packet.layers:
+                if (
+                    layer.layer_name == "quic"
+                    and hasattr(layer, "long_packet_type")
+                    and layer.long_packet_type == "2"
+                ):
+                    packets.append(layer)
+        return packets


### PR DESCRIPTION
Add a script to make Travis enforce formatting and linting using 3 tools:

- black ensures consistent formatting
- isort ensures consistent ordering of imports
- flake8 is a linter and catches things like unused imports and variables or references to non-existant variables