### PR TITLE
increase memlock ulimit for endpoint containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - sim
     cap_add: 
       - NET_ADMIN
+    ulimits:
+      memlock: 67108864
     networks:
       rightnet:
         ipv4_address: 193.167.100.100
@@ -60,6 +62,8 @@ services:
       - sim
     cap_add: 
       - NET_ADMIN
+    ulimits:
+      memlock: 67108864
     networks:
       leftnet:
         ipv4_address: 193.167.0.100


### PR DESCRIPTION
This should fix the crash I'm seeing with quic-go:
```
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
```

Updating the kernel is not possible without a big hassle, since Ubuntu 19.10 ships with 5.3.10.xx.