### PR TITLE
check return code for docker-compose commands at the end of a run

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -338,29 +338,32 @@ class InteropRunner:
             logging.debug("%s", r.stdout.decode("utf-8"))
 
         # copy the pcaps from the simulator
-        subprocess.run(
+        r = subprocess.run(
             'docker cp "$(docker-compose --log-level ERROR ps -q sim)":/logs/. '
             + sim_log_dir.name,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
+        r.check_returncode()
         # copy logs from the client
-        subprocess.run(
+        r = subprocess.run(
             'docker cp "$(docker-compose --log-level ERROR ps -q client)":/logs/. '
             + client_log_dir.name,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
+        r.check_returncode()
         # copy logs from the server
-        subprocess.run(
+        r = subprocess.run(
             'docker cp "$(docker-compose --log-level ERROR ps -q server)":/logs/. '
             + server_log_dir.name,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
+        r.check_returncode()
 
         if not expired:
             lines = output.splitlines()


### PR DESCRIPTION
check return code for docker-compose commands at the end of a run

for other subprocess invocations there are already checks on the output
and similar.
The cp commands at the end of the run were failing silently instead.
This solution throws an exception and makes it obvious that something
went wrong

```
$ python3 run.py -s quicgo -c mvfst -t resumption
Running with server quicgo (martenseemann/quic-go-interop:latest) and client mvfst (lnicco/mvfst-qns:latest)
quicgo client compliant.
quicgo server compliant.
mvfst client compliant.
mvfst server compliant.
Server: quicgo. Client: mvfst. Running test case: resumption
Traceback (most recent call last):
  File "run.py", line 110, in <module>
    output=get_args().json,
  File "/home/ubuntu/lnicco/docker-interop/quic-interop-runner/interop.py", line 454, in run
    status = self._run_testcase(server, client, testcase)
  File "/home/ubuntu/lnicco/docker-interop/quic-interop-runner/interop.py", line 255, in _run_testcase
    return self._run_test(server, client, None, test)[0]
  File "/home/ubuntu/lnicco/docker-interop/quic-interop-runner/interop.py", line 348, in _run_test
    r.check_returncode()
  File "/usr/lib/python3.6/subprocess.py", line 389, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command 'docker cp "$(docker-compose --log-level ERROR ps -q sim)":/logs/. /tmp/logs_sim_zomvdj0x' returned non-zero exit status 1.
```