### PR TITLE
keep the log files of multiple runs, and show them in the web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 logs/
 logs_*/
 *.json
+web/latest
 
 *.egg-info/
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 logs/
+logs_*/
 *.json
 
 *.egg-info/

--- a/cron.py
+++ b/cron.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import os
+import os.path
+import shutil
+import sys
+from datetime import datetime
+
+from interop import InteropRunner
+from run import client_implementations, implementations, server_implementations
+from testcases import MEASUREMENTS, TESTCASES
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n", "--numlogs", help="keep this many logs")
+    return parser.parse_args()
+
+
+try:
+    numlogs = int(get_args().numlogs)
+except Exception as e:
+    logging.info(e)
+    sys.exit("Invalid -n argument.")
+
+log_dir = "logs_{:%Y-%m-%dT%H:%M:%S}UTC".format(datetime.utcnow())
+
+InteropRunner(
+    implementations=implementations,
+    servers=server_implementations,
+    clients=client_implementations,
+    tests=TESTCASES,
+    measurements=MEASUREMENTS,
+    output=log_dir + "/result.json",
+    log_dir=log_dir,
+).run()
+
+web_dir = "web/"  # directory of the index.html of the interop runner website
+logs_file = web_dir + "logs.txt"
+try:
+    with open(logs_file, "r") as f:
+        lines = json.load(f)
+except FileNotFoundError:
+    lines = []
+
+# make sure that web/ doesn't contain more than x old runs
+while len(lines) >= numlogs:
+    d = web_dir + lines[0]
+    logging.info("Deleting %s.", d)
+    shutil.rmtree(d)
+    lines = lines[1:]
+
+with open(logs_file, "w") as f:
+    lines.append(log_dir)
+    json.dump(lines, f)
+
+# move log dir to the web folder
+shutil.move(log_dir, web_dir + "/")
+# adjust web/latest to point to the latest run
+latest_symlink = web_dir + "latest"
+try:
+    os.remove(latest_symlink)
+except FileNotFoundError:
+    pass
+os.symlink(src=log_dir, dst=latest_symlink, target_is_directory=True)

--- a/cron.py
+++ b/cron.py
@@ -39,7 +39,7 @@ InteropRunner(
 ).run()
 
 web_dir = "web/"  # directory of the index.html of the interop runner website
-logs_file = web_dir + "logs.txt"
+logs_file = web_dir + "logs.json"
 try:
     with open(logs_file, "r") as f:
         lines = json.load(f)

--- a/interop.py
+++ b/interop.py
@@ -64,6 +64,7 @@ class InteropRunner:
         tests: List[testcases.TestCase],
         measurements: List[testcases.Measurement],
         output: str,
+        log_dir="",
     ):
         self._start_time = datetime.now()
         self._tests = tests
@@ -72,7 +73,9 @@ class InteropRunner:
         self._clients = clients
         self._implementations = implementations
         self._output = output
-        self._log_dir = "logs_{:%Y-%m-%dT%H:%M:%S}".format(self._start_time)
+        self._log_dir = log_dir
+        if len(self._log_dir) == 0:
+            self._log_dir = "logs_{:%Y-%m-%dT%H:%M:%S}".format(self._start_time)
         if os.path.exists(self._log_dir):
             sys.exit("Log dir " + self._log_dir + " already exists.")
         logging.debug("Saving logs to %s.", self._log_dir)

--- a/run.py
+++ b/run.py
@@ -10,42 +10,6 @@ from implementations import IMPLEMENTATIONS
 from interop import InteropRunner
 from testcases import MEASUREMENTS, TESTCASES
 
-
-def get_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-d",
-        "--debug",
-        action="store_const",
-        const=True,
-        default=False,
-        help="turn on debug logs",
-    )
-    parser.add_argument(
-        "-s", "--server", help="server implementations (comma-separated)"
-    )
-    parser.add_argument(
-        "-c", "--client", help="client implementations (comma-separated)"
-    )
-    parser.add_argument("-t", "--test", help="test cases (comma-separatated)")
-    parser.add_argument(
-        "-r",
-        "--replace",
-        help="replace path of implementation. Example: -r myquicimpl=dockertagname",
-    )
-    parser.add_argument("-j", "--json", help="output the matrix to file in json format")
-    return parser.parse_args()
-
-
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-console = logging.StreamHandler(stream=sys.stderr)
-if get_args().debug:
-    console.setLevel(logging.DEBUG)
-else:
-    console.setLevel(logging.INFO)
-logger.addHandler(console)
-
 implementations = {name: value["url"] for name, value in IMPLEMENTATIONS.items()}
 client_implementations = [
     name
@@ -58,54 +22,93 @@ server_implementations = [
     if value["role"] == 1 or value["role"] == 2
 ]
 
-replace_arg = get_args().replace
-if replace_arg:
-    for s in replace_arg.split(","):
-        pair = s.split("=")
-        if len(pair) != 2:
-            sys.exit("Invalid format for replace")
-        name, image = pair[0], pair[1]
-        if name not in IMPLEMENTATIONS:
-            sys.exit("Implementation " + name + " not found.")
-        implementations[name] = image
+
+def main():
+    def get_args():
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-d",
+            "--debug",
+            action="store_const",
+            const=True,
+            default=False,
+            help="turn on debug logs",
+        )
+        parser.add_argument(
+            "-s", "--server", help="server implementations (comma-separated)"
+        )
+        parser.add_argument(
+            "-c", "--client", help="client implementations (comma-separated)"
+        )
+        parser.add_argument("-t", "--test", help="test cases (comma-separatated)")
+        parser.add_argument(
+            "-r",
+            "--replace",
+            help="replace path of implementation. Example: -r myquicimpl=dockertagname",
+        )
+        parser.add_argument(
+            "-j", "--json", help="output the matrix to file in json format"
+        )
+        return parser.parse_args()
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    console = logging.StreamHandler(stream=sys.stderr)
+    if get_args().debug:
+        console.setLevel(logging.DEBUG)
+    else:
+        console.setLevel(logging.INFO)
+    logger.addHandler(console)
+
+    replace_arg = get_args().replace
+    if replace_arg:
+        for s in replace_arg.split(","):
+            pair = s.split("=")
+            if len(pair) != 2:
+                sys.exit("Invalid format for replace")
+            name, image = pair[0], pair[1]
+            if name not in IMPLEMENTATIONS:
+                sys.exit("Implementation " + name + " not found.")
+            implementations[name] = image
+
+    def get_impls(arg, availableImpls, role) -> List[str]:
+        if not arg:
+            return availableImpls
+        impls = []
+        for s in arg.split(","):
+            if s not in availableImpls:
+                sys.exit(role + " implementation " + s + " not found.")
+            impls.append(s)
+        return impls
+
+    def get_tests_and_measurements(
+        arg,
+    ) -> Tuple[List[testcases.TestCase], List[testcases.TestCase]]:
+        if arg is None:
+            return TESTCASES, MEASUREMENTS
+        elif not arg:
+            return []
+        tests = []
+        measurements = []
+        for t in arg.split(","):
+            if t in [tc.name() for tc in TESTCASES]:
+                tests += [tc for tc in TESTCASES if tc.name() == t]
+            elif t in [tc.name() for tc in MEASUREMENTS]:
+                measurements += [tc for tc in MEASUREMENTS if tc.name() == t]
+            else:
+                sys.exit("Test case " + t + " not found.")
+        return tests, measurements
+
+    t = get_tests_and_measurements(get_args().test)
+    InteropRunner(
+        implementations=implementations,
+        servers=get_impls(get_args().server, server_implementations, "Server"),
+        clients=get_impls(get_args().client, client_implementations, "Client"),
+        tests=t[0],
+        measurements=t[1],
+        output=get_args().json,
+    ).run()
 
 
-def get_impls(arg, availableImpls, role) -> List[str]:
-    if not arg:
-        return availableImpls
-    impls = []
-    for s in arg.split(","):
-        if s not in availableImpls:
-            sys.exit(role + " implementation " + s + " not found.")
-        impls.append(s)
-    return impls
-
-
-def get_tests_and_measurements(
-    arg,
-) -> Tuple[List[testcases.TestCase], List[testcases.TestCase]]:
-    if arg is None:
-        return TESTCASES, MEASUREMENTS
-    elif not arg:
-        return []
-    tests = []
-    measurements = []
-    for t in arg.split(","):
-        if t in [tc.name() for tc in TESTCASES]:
-            tests += [tc for tc in TESTCASES if tc.name() == t]
-        elif t in [tc.name() for tc in MEASUREMENTS]:
-            measurements += [tc for tc in MEASUREMENTS if tc.name() == t]
-        else:
-            sys.exit("Test case " + t + " not found.")
-    return tests, measurements
-
-
-t = get_tests_and_measurements(get_args().test)
-InteropRunner(
-    implementations=implementations,
-    servers=get_impls(get_args().server, server_implementations, "Server"),
-    clients=get_impls(get_args().client, client_implementations, "Client"),
-    tests=t[0],
-    measurements=t[1],
-    output=get_args().json,
-).run()
+if __name__ == "__main__":
+    main()

--- a/web/index.html
+++ b/web/index.html
@@ -16,6 +16,7 @@
   
   <div class="container">
     <div class="runstats">
+      Run: <div id="available-runs"></div><br>
       Start Time: <em><span id="lastrun"></span></em><br>
       Duration: <em><span id="duration"></span></em>
     </div>

--- a/web/script.js
+++ b/web/script.js
@@ -105,7 +105,7 @@
 
   var xhr = new XMLHttpRequest();
   xhr.responseType = 'json';
-  xhr.open('GET', 'result.json');
+  xhr.open('GET', 'latest/result.json');
 
   xhr.onreadystatechange = function() {
     if(xhr.readyState !== XMLHttpRequest.DONE) {

--- a/web/script.js
+++ b/web/script.js
@@ -95,7 +95,7 @@
   function process(result) {
     var startTime = new Date(1000*result.start_time);
     var endTime = new Date(1000*result.end_time);
-    document.getElementById("lastrun").innerHTML = startTime.toLocaleDateString("en-US") + " " + startTime.toLocaleTimeString("en-US");
+    document.getElementById("lastrun").innerHTML = startTime.toLocaleDateString("en-US",  { timeZone: 'UTC' }) + " " + startTime.toLocaleTimeString("en-US", { timeZone: 'UTC', timeZoneName: 'short' });
     document.getElementById("duration").innerHTML = formatTime(result.end_time - result.start_time);
 
     fillInteropTable(result)

--- a/web/script.js
+++ b/web/script.js
@@ -8,10 +8,11 @@
     ].join(":").replace(/\b(\d)\b/g, "0$1")
   }
 
-  function getLogLink(server, client, testcase, text) {
+  function getLogLink(log_dir, server, client, testcase, text) {
+    if(log_dir.length == 0) log_dir = "logs"; // backwards-compatibility mode
     var a = document.createElement("a");
     a.title = "Logs";
-    a.href = "logs/" + server + "_" + client + "/" + testcase;
+    a.href = log_dir + "/" + server + "_" + client + "/" + testcase;
     a.target = "_blank";
     a.appendChild(document.createTextNode(text));
     return a;
@@ -32,7 +33,7 @@
         var cell = row.insertCell(j+1);
         var appendResult = function(el, res) {
           result.results[index].forEach(function(item) {
-            if(item.result == res) el.appendChild(getLogLink(result.servers[j], result.clients[i], item.name, item.abbr))
+            if(item.result == res) el.appendChild(getLogLink(result.log_dir, result.servers[j], result.clients[i], item.name, item.abbr))
           });
           cell.appendChild(el);
         }
@@ -69,7 +70,7 @@
         for(var k = 0; k < res.length; k++) {
           var measurement = res[k];
           var el = document.createElement("div");
-          var link = getLogLink(result.servers[j], result.clients[i], measurement.name, measurement.abbr);
+          var link = getLogLink(result.log_dir, result.servers[j], result.clients[i], measurement.name, measurement.abbr);
           switch(measurement.result) {
             case "succeeded":
               el.className = "text-success";

--- a/web/script.js
+++ b/web/script.js
@@ -20,6 +20,7 @@
 
   function fillInteropTable(result) {
     var t = document.getElementById("interop");
+    t.innerHTML = "";
     var row = t.insertRow(0);
     row.insertCell(0);
     for(var i = 0; i < result.servers.length; i++) {
@@ -54,6 +55,7 @@
 
   function fillMeasurementTable(result) {
     var t = document.getElementById("measurements");
+    t.innerHTML = "";
     var row = t.insertRow(0);
     row.insertCell(0);
     for(var i = 0; i < result.servers.length; i++) {
@@ -103,10 +105,30 @@
     fillMeasurementTable(result)
   }
 
+  function load(dir) {
+    var xhr = new XMLHttpRequest();
+    xhr.responseType = 'json';
+    xhr.open('GET', dir + '/result.json');
+    xhr.onreadystatechange = function() {
+      if(xhr.readyState !== XMLHttpRequest.DONE) {
+        return;
+      }
+      if(xhr.status != 200) {
+        console.log("Received status");
+        console.log(xhr.status);
+        return;
+      }
+      process(xhr.response);
+    };
+    xhr.send();
+  }
+
+  load("latest");
+
+  // enable loading of old runs
   var xhr = new XMLHttpRequest();
   xhr.responseType = 'json';
-  xhr.open('GET', 'latest/result.json');
-
+  xhr.open('GET', 'logs.json');
   xhr.onreadystatechange = function() {
     if(xhr.readyState !== XMLHttpRequest.DONE) {
       return;
@@ -116,7 +138,17 @@
       console.log(xhr.status);
       return;
     }
-    process(xhr.response);
+    var s = document.createElement("select");
+    xhr.response.reverse().forEach(function(el) {
+      var opt = document.createElement("option");
+      opt.innerHTML = el.substr(5);
+      opt.value = el;
+      s.appendChild(opt);
+    })
+    s.addEventListener("change", function(ev) {
+      load(ev.currentTarget.value);
+    })
+    document.getElementById("available-runs").appendChild(s);
   };
   xhr.send();
 })();

--- a/web/styles.css
+++ b/web/styles.css
@@ -9,6 +9,11 @@
   text-align: right;
 }
 
+#available-runs {
+  margin-left: 5px;
+  display: inline-block;
+}
+
 table.resulttable td {
   vertical-align: middle;
 }


### PR DESCRIPTION
It's annoying that results disappear all the time. It's even more annoying that it's not predictable when this happens, and that the links to log files are just replaced by new files.

This PR:
* creates unique directory names for runs. For example, the link to a run will be https://interop.seemann.io/logs_20-04-11T16:21:04UTC/quicly_quicgo/handshake/. This link remains valid after another run of the interop runner. If at some point logs are deleted, it will 404.
* moves some of the logic of the previous cron job (which was not committed to CVS) to `cron.py`. This script runs the interop runner, and saves the log files. If there are more than `n` log file directories, it deletes the oldest one(s).
* adds a selector in the web interface to access all runs that we have log files available for.