### PR TITLE
add a ChaCha20 test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Currently disabled due to #20.
 
 * **Transfer** (`transfer`): Tests both flow control and stream multiplexing. The client should use small initial flow control windows for both stream- and connection-level flow control, such that the during the transfer of files on the order of 1 MB the flow control window needs to be increased. The client is exepcted to establish a single QUIC connection, and use multiple streams to concurrently download the files.
 
+* **ChaCha20** (`chacha20`, only for the client): In this test, the client is expected to offer **only** ChaCha20 as a ciphersuite, and download the files.
+
 * **Retry** (`retry`): Tests that the server can generate a Retry, and that the client can act upon it (i.e. use the Token provided in the Retry packet in the Initial packet).
 
 * **Resumption** (`resumption`): Tests QUIC session resumption (without 0-RTT). The client is expected to establish a connection and download the first file. The server is expected to provide the client with a session ticket that allows it to resume the connection. After downloading the first file, the client has to close the connection, establish a resumed connection using the session ticket, and use this connection to download the remaining file(s).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - SERVER_PARAMS=$SERVER_PARAMS
       - SSLKEYLOGFILE=/logs/keys.log
       - QLOGDIR=/logs/qlog/
-      - TESTCASE=$TESTCASE
+      - TESTCASE=$TESTCASE_SERVER
     depends_on:
       - sim
     cap_add: 
@@ -56,7 +56,7 @@ services:
       - CLIENT_PARAMS=$CLIENT_PARAMS
       - SSLKEYLOGFILE=/logs/keys.log
       - QLOGDIR=/logs/qlog/
-      - TESTCASE=$TESTCASE
+      - TESTCASE=$TESTCASE_CLIENT
       - REQUESTS=$REQUESTS
     depends_on:
       - sim

--- a/interop.py
+++ b/interop.py
@@ -17,6 +17,7 @@ import prettytable
 from termcolor import colored
 
 import testcases
+from testcases import Perspective
 
 
 def random_string(length: int):
@@ -323,7 +324,8 @@ class InteropRunner:
         reqs = " ".join(["https://server:443/" + p for p in testcase.get_paths()])
         logging.debug("Requests: %s", reqs)
         params = (
-            "TESTCASE=" + testcase.testname() + " "
+            "TESTCASE_SERVER=" + testcase.testname(Perspective.SERVER) + " "
+            "TESTCASE_CLIENT=" + testcase.testname(Perspective.CLIENT) + " "
             "WWW=" + testcase.www_dir() + " "
             "DOWNLOADS=" + testcase.download_dir() + " "
             "SERVER_LOGS=" + server_log_dir.name + " "


### PR DESCRIPTION
I noticed that most implementations always negotiate AES. After discovering a few bugs in quic-go related to the ChaCha20 header protection, I thought it might be a good idea to have an interop test for this.

To support this test case, the client needs to support the `chacha20` test case. In this test case, it must only offer the ChaCha20 cipher suite during the handshake. This guarantees that if the transfer completes, ChaCha20 was actually used.
Servers don't need to change anything to support this test case.