### PR TITLE
slightly reduce the file name length in the 0-RTT test case

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -462,7 +462,7 @@ class TestCaseResumption(TestCase):
 class TestCaseZeroRTT(TestCase):
     NUM_FILES = 40
     FILESIZE = 32  # in bytes
-    FILENAMELEN = 255
+    FILENAMELEN = 250
 
     @staticmethod
     def name():


### PR DESCRIPTION
Operating right at the length limit of the file system is annoying, for example if you want to gzip the files...