### PR TITLE
Added per-server view of results.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,6 @@
     <span class="navbar-brand">QUIC Interop Runner</span>
     <div class="collapse navbar-collapse"></div>
   </div>
-  
   <div class="container">
     <div class="runstats">
       Run: <div id="available-runs"></div><br>
@@ -25,6 +24,9 @@
 
     <h3>Measurements</h3>
     <table id="measurements" class="resulttable table table-hover"></table>
+
+    <h3>Interop per server</h3>
+    <table id="interop_per_server" class="resulttable table table-hover"></table>
   </div>
   <script src="script.js"></script>
 </body>

--- a/web/script.js
+++ b/web/script.js
@@ -24,13 +24,75 @@
     return a;
   }
 
+  function getServerLink(result, server_name, server_idx) {
+    var a = document.createElement("a");
+    a.title = server_name;
+    a.onclick = function(){ fillFeaturesTable(result, server_idx); return false; };
+    a.href = "/";
+    a.target = "_blank";
+    a.appendChild(document.createTextNode(server_name));
+    return a;
+  }
+
+  function appendFeatureResult(el, res, j, i, result, item, cell) {
+    if(item.result != res) return;
+    if(res == "unsupported") {
+      el.appendChild(getUnsupported(res));
+    } else {
+      el.appendChild(getLogLink(result.log_dir, result.servers[j], result.clients[i], item.name, item.result))
+    }
+    cell.appendChild(el);
+  }
+
+  function fillFeaturesTable(result, srv_idx) {
+    var t = document.getElementById("interop_per_server");
+    t.innerHTML = "";
+    var row = t.insertRow(0);
+    row.insertCell(0).innerHTML="server: " + result.servers[srv_idx];
+    for(var i = 0; i < result.clients.length; i++) {
+        row.insertCell(i+1).innerHTML = result.clients[i];
+    }
+
+    var my_res = result.results[srv_idx];
+
+    for (k = 0; k < my_res.length; ++k) {
+      var item = my_res[k];
+      var row = t.insertRow(k + 1);
+      row.insertCell(0).innerHTML = item.name;
+
+      var j = 0;
+      for (var i = srv_idx; i < result.results.length; i += result.servers.length) {
+
+        var cell = row.insertCell(j + 1);
+
+        cell.className = "results";
+
+        var feature_res = result.results[i][k];
+
+        var succeeded = document.createElement("div");
+        succeeded.className = "text-success";
+        appendFeatureResult(succeeded, "succeeded", srv_idx, j, result, feature_res, cell);
+
+        var unsupported = document.createElement("div");
+        unsupported.className = "text-secondary";
+        appendFeatureResult(unsupported, "unsupported", srv_idx, j, result, feature_res, cell);
+
+        var failed = document.createElement("div");
+        failed.className = "text-danger";
+        appendFeatureResult(failed, "failed", srv_idx, j, result, feature_res, cell);
+
+        j = j + 1;
+      }
+    }
+  }
+
   function fillInteropTable(result) {
     var t = document.getElementById("interop");
     t.innerHTML = "";
     var row = t.insertRow(0);
     row.insertCell(0);
     for(var i = 0; i < result.servers.length; i++) {
-      row.insertCell(i+1).innerHTML = result.servers[i];
+      row.insertCell(i+1).appendChild(getServerLink(result, result.servers[i], i));
     }
     var index = 0;
     for(var i = 0; i < result.clients.length; i++) {


### PR DESCRIPTION
The full interop table is very confusing: a lot of abbreviations wihout
explanation on same page, and is not very practical, when you want to
track specific implementation.

The patch adds one more table, that shows how different clients interact
with selected server.  Just click on the server name in the table head,
and the table below will be populated.  The left part of the table
contains non-abbreviated feature names.