### PR TITLE
add a command line flag to pull.py to pull specific implementations

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -1,4 +1,6 @@
+import argparse
 import os
+import sys
 
 from implementations import IMPLEMENTATIONS
 
@@ -8,6 +10,22 @@ os.system("docker pull martenseemann/quic-network-simulator")
 print("\nPulling the iperf endpoint...")
 os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
 
-for name, value in IMPLEMENTATIONS.items():
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--implementations", help="implementations to pull")
+    return parser.parse_args()
+
+
+implementations = {}
+if get_args().implementations:
+    for s in get_args().implementations.split(","):
+        if s not in [n for n, _ in IMPLEMENTATIONS.items()]:
+            sys.exit("implementation " + s + " not found.")
+        implementations[s] = IMPLEMENTATIONS[s]
+else:
+    implementations = IMPLEMENTATIONS
+
+for name, value in implementations.items():
     print("\nPulling " + name + "...")
     os.system("docker pull " + value["url"])


### PR DESCRIPTION
cc @nibanks 

Example:
```bash
python3 pull.py -i quic-go,quicly,msquic
```

Note: The network simulator and the iperf endpoint are always pulled.