### PR TITLE
Renew anonymous volumes

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -129,7 +129,7 @@ class InteropRunner:
             "DOWNLOADS=" + downloads_dir.name + " "
             'SCENARIO="simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25" '
             "CLIENT=" + self._implementations[name] + " "
-            "docker-compose up --timeout 0 --abort-on-container-exit sim client"
+            "docker-compose up --timeout 0 --abort-on-container-exit -V sim client"
         )
         output = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
@@ -151,7 +151,7 @@ class InteropRunner:
             "WWW=" + www_dir.name + " "
             "DOWNLOADS=" + downloads_dir.name + " "
             "SERVER=" + self._implementations[name] + " "
-            "docker-compose up server"
+            "docker-compose up -V server"
         )
         output = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT


### PR DESCRIPTION
This helps during development, when volumes might go missing.

`-V` [documentation](https://docs.docker.com/compose/reference/up/) says:

```
    -V, --renew-anon-volumes   Recreate anonymous volumes instead of retrieving
                               data from the previous containers.
```

In other words, it says that you should not try to revive a stopped image that you previously used, but go back to docker and load the image.  I think that this means "don't cache $something".  All I know is that it works.

Sorry about targeting the wrong repo.  I don't know what happened.

Closes #137.