### PR TITLE
export the implemenations in JSON format

### DIFF
--- a/implementations.py
+++ b/implementations.py
@@ -1,3 +1,6 @@
+import json
+import sys
+
 # add your QUIC implementation here
 IMPLEMENTATIONS = {  # name => [ docker image, role ]; role: 0 == 'client', 1 == 'server', 2 == both
     "quic-go": {"url": "martenseemann/quic-go-interop:latest", "role": 2},
@@ -14,3 +17,27 @@ IMPLEMENTATIONS = {  # name => [ docker image, role ]; role: 0 == 'client', 1 ==
     "msquic": {"url": "mcr.microsoft.com/msquic/qns:latest", "role": 1},
     "pquic": {"url": "pquic/pquic-interop:latest", "role": 2},
 }
+
+
+def main():
+    """
+    export the list of client and server implementations in JSON format
+    """
+    print(
+        json.dumps(
+            {
+                "server": [
+                    name for name, val in IMPLEMENTATIONS.items() if val["role"] > 0
+                ],
+                "client": [
+                    name
+                    for name, val in IMPLEMENTATIONS.items()
+                    if val["role"] % 2 == 0
+                ],
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
cc @nibanks

Running `python3 implementations.py` would now output:
```json
{
    "server": ["quic-go", "quicly", "ngtcp2", "quant", "mvfst", "quiche", "picoquic", "aioquic", "neqo", "nginx", "msquic", "pquic"],
    "client": ["quic-go", "quicly", "ngtcp2", "quant", "mvfst", "quiche", "kwik", "picoquic", "aioquic", "neqo", "pquic"]}
}
```

We can use that in the CI config to retrieve the list of implementations, so that we only have to hard-code them in a single place (`implementations.py`).