### PR TITLE
only upload interop results for scheduled runs

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -85,6 +85,7 @@ jobs:
           find logs_measurement -depth -name "server" -type d -exec rm -r "{}" \;
           mv logs_measurement/${{ matrix.server }}_${{ matrix.client }}/* logs/${{ matrix.server }}_${{ matrix.client }}/
       - name: Upload logs
+        if: ${{ github.event_name == "schedule" }}
         uses: appleboy/scp-action@master
         with:
           host: interop.seemann.io
@@ -115,6 +116,7 @@ jobs:
       - name: Aggregate results
         run: python .github/workflows/aggregate.py --server ${{ join(fromJson(needs.matrix.outputs.matrix).server, ',') }} --client ${{ join(fromJson(needs.matrix.outputs.matrix).client, ',') }} --log-dir=${{ github.run_id }} --output result.json
       - name: Upload result
+        if: ${{ github.event_name == "schedule" }}
         uses: appleboy/scp-action@master
         with:
           host: interop.seemann.io
@@ -123,6 +125,7 @@ jobs:
           source: result.json
           target: /root/src/quic-interop-runner/web/${{ github.run_id }}
       - name: Publish result
+        if: ${{ github.event_name == "schedule" }}
         uses: appleboy/ssh-action@master
         with:
           host: interop.seemann.io


### PR DESCRIPTION
This makes it easier to try out new things in the interop script, without uploading new results for every run.
Results are only uploaded if this run was triggered by the cron scheduler.