### PR TITLE
Update ngtcp2 image

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -8,7 +8,7 @@
     "role": "both"
   },
   "ngtcp2": {
-    "url": "ngtcp2/ngtcp2-interop:latest",
+    "url": "ghcr.io/ngtcp2/ngtcp2-interop:latest",
     "role": "both"
   },
   "quant": {


### PR DESCRIPTION
ngtcp2 interop image has moved to ghcr.io.