### PR TITLE
speed up the Wireshark build

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -11,18 +11,19 @@ jobs:
         with:
           repository: wireshark/wireshark
       - name: Install dependencies
+        run: sudo apt-get install -y cmake libglib2.0-dev libc-ares-dev libgcrypt20-dev flex bison byacc libpcap-dev ninja-build
+      - name: Build Wireshark
         run: |
-          sudo tools/debian-setup.sh --install-deb-deps --install-optional
-      - name: Build packages
-        run: |
-          dpkg-buildpackage
-          mkdir packages
-          mv ../*.deb packages
-      - name: Upload packages
+          cmake -GNinja -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=0 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DENABLE_STATIC=1 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 .
+          ninja
+      - run: run/tshark -v
+      - name: Compress
+        run: tar -czvf tshark.tar.gz -C run/ tshark
+      - name: Upload
         uses: actions/upload-artifact@v2
         with:
           name: wireshark
-          path: packages
+          path: tshark.tar.gz
   matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -143,17 +144,13 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: wireshark
-          path: packages
+          path: wireshark
       - name: Install Wireshark
         run: |
-          sudo dpkg -i \
-            packages/libwireshark-data_*.deb \
-            packages/libwireshark0_*.deb \
-            packages/libwiretap0_*.deb \
-            packages/libwsutil0_*.deb \
-            packages/tshark_*.deb \
-            packages/wireshark-common_*.deb || true
-          sudo apt-get -f install
+          cd wireshark
+          tar xfz tshark.tar.gz
+          sudo mv tshark /usr/local/bin
+          cd .. && rm -r wireshark
       - name: Install Python packages
         run: |
           pip install -U pip


### PR DESCRIPTION
This brings down the compilation time of Wireshark from 15 to 5 minutes. It also speeds up the installation of tshark on the test images (which took around ~45s), as we only have to install tshark, and not the Debian packages containing all Wireshark tools. Now installing tshark only takes ~5s.

Thanks to @Lekensteyn for helping me with the build configuration.