### PR TITLE
gzip log files

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -174,6 +174,11 @@ jobs:
           find logs_measurement -depth -name "client" -type d -exec rm -r "{}" \;
           find logs_measurement -depth -name "server" -type d -exec rm -r "{}" \;
           mv logs_measurement/${{ matrix.server }}_${{ matrix.client }}/* logs/${{ matrix.server }}_${{ matrix.client }}/
+      - run: du -sh logs
+      - name: Compress logs
+        # compress all files (except JSON files), to the same file name
+        run: find . -type f ! -name "*.json" -exec gzip -v {} \; -exec mv {}.gz {} \;
+      - run: du -sh logs
       - name: Upload logs
         if: ${{ github.event_name == 'schedule' }}
         uses: appleboy/scp-action@master

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -1,0 +1,26 @@
+{
+  experimental_http3
+}
+
+interop.seemann.io:443
+
+# The website must be mounted at /var/www/web.
+# The log directory must be mounted at /var/www/logs.
+root /logs/* /var/www/
+root * /var/www/web
+
+# All logs files except .json files are gzipped.
+@islogfile {
+  file {path} # make sure that directoy listings are not compressed.
+  path /logs/*
+  not path *.json
+}
+
+handle @islogfile {
+  header Content-Encoding gzip
+  file_server browse
+}
+
+handle not @islogfile {
+  file_server browse
+}

--- a/web/script.js
+++ b/web/script.js
@@ -11,7 +11,7 @@
   function getLogLink(log_dir, server, client, testcase, text) {
     var a = document.createElement("a");
     a.title = "Logs";
-    a.href = log_dir + "/" + server + "_" + client + "/" + testcase;
+    a.href = "logs/" + log_dir + "/" + server + "_" + client + "/" + testcase;
     a.target = "_blank";
     a.appendChild(document.createTextNode(text));
     return a;
@@ -144,7 +144,7 @@
   // enable loading of old runs
   var xhr = new XMLHttpRequest();
   xhr.responseType = 'json';
-  xhr.open('GET', 'logs.json');
+  xhr.open('GET', 'logs/logs.json');
   xhr.onreadystatechange = function() {
     if(xhr.readyState !== XMLHttpRequest.DONE) {
       return;


### PR DESCRIPTION
A single run currently generates about 25 GB of log files. We can gzip these files and reduce the file size to ~8.5 GB. Note that we're gzipping to the same filename, i.e. the compressed `output.txt` still have the filename `output.txt`, but now contain gzipped bytes. This is necessary to make sure we can easily serve those files over HTTP.

Using the Caddyfile in the web directory, we instruct Caddy to serve these gzipped files with the correct Content-Encoding, so the browser will handle the decompression of these files when accessing them via interop.seemann.io.

Note to myself: Change DNS entries to the new interop server that holds the compressed version of existing log files before merging this PR.