### PR TITLE
change paths of the log directory for the new interop.seemann.io setup

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -182,7 +182,7 @@ jobs:
           username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           source: logs/${{ matrix.server }}_${{ matrix.client }}
-          target: /root/src/quic-interop-runner/web/${{ github.run_id }}
+          target: /mnt/logs/${{ github.run_id }}
           strip_components: 1
       - name: Upload result
         uses: actions/upload-artifact@v2
@@ -213,7 +213,7 @@ jobs:
           username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           source: result.json
-          target: /root/src/quic-interop-runner/web/${{ github.run_id }}
+          target: /mnt/logs/${{ github.run_id }}
       - name: Publish result
         if: ${{ github.event_name == 'schedule' }}
         uses: appleboy/ssh-action@master
@@ -222,6 +222,6 @@ jobs:
           username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           script: |
-            cd /root/src/quic-interop-runner/web/
+            cd /mnt/logs
             jq '. += [ "${{ github.run_id }}" ]' logs.json | sponge logs.json
             rm latest && ln -s ${{ github.run_id }} latest

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -1,0 +1,12 @@
+{
+  experimental_http3
+}
+
+interop.seemann.io:443
+
+# The website must be mounted at /var/www/web.
+# The log directory must be mounted at /var/www/logs.
+root /logs/* /var/www/
+root * /var/www/web
+
+file_server browse

--- a/web/script.js
+++ b/web/script.js
@@ -11,7 +11,7 @@
   function getLogLink(log_dir, server, client, testcase, text) {
     var a = document.createElement("a");
     a.title = "Logs";
-    a.href = log_dir + "/" + server + "_" + client + "/" + testcase;
+    a.href = "logs/" + log_dir + "/" + server + "_" + client + "/" + testcase;
     a.target = "_blank";
     a.appendChild(document.createTextNode(text));
     return a;
@@ -124,7 +124,7 @@
   function load(dir) {
     var xhr = new XMLHttpRequest();
     xhr.responseType = 'json';
-    xhr.open('GET', dir + '/result.json');
+    xhr.open('GET', 'logs/' + dir + '/result.json');
     xhr.onreadystatechange = function() {
       if(xhr.readyState !== XMLHttpRequest.DONE) {
         return;
@@ -144,7 +144,7 @@
   // enable loading of old runs
   var xhr = new XMLHttpRequest();
   xhr.responseType = 'json';
-  xhr.open('GET', 'logs.json');
+  xhr.open('GET', 'logs/logs.json');
   xhr.onreadystatechange = function() {
     if(xhr.readyState !== XMLHttpRequest.DONE) {
       return;


### PR DESCRIPTION
I moved interop.seemann.io to a new (much weaker, CPU- and RAM-wise) server. This will allow us to spend more on hard drive space for logs, if necessary.