### PR TITLE
fade the result tables while loading a new result

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -122,6 +122,7 @@
   }
 
   function load(dir) {
+    document.getElementsByTagName("body")[0].classList.add("loading");
     var xhr = new XMLHttpRequest();
     xhr.responseType = 'json';
     xhr.open('GET', dir + '/result.json');
@@ -135,6 +136,7 @@
         return;
       }
       process(xhr.response);
+      document.getElementsByTagName("body")[0].classList.remove("loading");
     };
     xhr.send();
   }

--- a/web/styles.css
+++ b/web/styles.css
@@ -14,6 +14,10 @@
   display: inline-block;
 }
 
+body.loading table.resulttable {
+  opacity: 0.3;
+}
+
 table.resulttable td {
   vertical-align: middle;
   font-size: 0.8rem;


### PR DESCRIPTION
Sometimes it takes a second or so to load the result. This PR adds a visual loading indication.
Already deployed on interop.seemann.io.