### PR TITLE
Add an ECN testcase

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -786,6 +786,10 @@ class TestCaseECN(TestCaseHandshake):
         if not super(TestCaseECN, self).check():
             return False
 
+        if not self._keylog_file():
+            logging.info("No SSLKEYLOG file available")
+            return False
+
         tr_client = self._client_trace()._get_packets(
             self._client_trace()._get_direction_filter(Direction.FROM_CLIENT) + " quic"
         )

--- a/testcases.py
+++ b/testcases.py
@@ -752,10 +752,6 @@ class TestCaseECN(TestCaseHandshake):
     def abbreviation():
         return "E"
 
-    @staticmethod
-    def testname(p: Perspective):
-        return "handshake"
-
     def count_ecn(self, tr):
         ecn = [0] * (max(ECN) + 1)
         for p in tr:

--- a/testcases.py
+++ b/testcases.py
@@ -762,7 +762,7 @@ class TestCaseECN(TestCaseHandshake):
             e = int(getattr(p["ip"], "dsfield.ecn"))
             ecn[e] += 1
         for e in ECN:
-            logging.info("%s %d", e, ecn[e])
+            logging.debug("%s %d", e, ecn[e])
         return ecn
 
     def check_ecn(self, e):

--- a/testcases.py
+++ b/testcases.py
@@ -807,7 +807,7 @@ class TestCaseECN(TestCaseHandshake):
         else:
             if ack_ecn_server_ok is False:
                 logging.info("Server did not send any ACK-ECN frames")
-            if ack_ecn_server_ok is True and ecn_client_all_ok is False:
+            elif ecn_client_all_ok is False:
                 logging.info(
                     "Not all client packets were consistently marked with ECT(0) or ECT(1)"
                 )
@@ -817,7 +817,7 @@ class TestCaseECN(TestCaseHandshake):
         else:
             if ack_ecn_client_ok is False:
                 logging.info("Client did not send any ACK-ECN frames")
-            if ack_ecn_client_ok and ecn_server_all_ok is False:
+            elif ecn_server_all_ok is False:
                 logging.info(
                     "Not all server packets were consistently marked with ECT(0) or ECT(1)"
                 )

--- a/testcases.py
+++ b/testcases.py
@@ -776,24 +776,30 @@ class TestCaseECN(TestCaseHandshake):
         if not super(TestCaseECN, self).check():
             return False
 
-        tr_client = self._client_trace()
-        tr_server = self._server_trace()
+        # This test currently *only* checks that all packets are consistently marked ECT(0) or ECT(1) in each direction
+        # FIXME: We importantly also need to test whether ACK-ECN is being sent in reply
 
+        tr_client = self._client_trace()
         ecn_client = self.count_ecn(
             tr_client._get_packets(
                 tr_client._get_direction_filter(Direction.FROM_CLIENT) + " quic"
             )
         )
+        ok_client = self.check_ecn(ecn_client)
+        if ok_client == False:
+            logging.info("Not all client packets were consistently marked with ECT(0) or ECT(1)")
+
+        tr_server = self._server_trace()
         ecn_server = self.count_ecn(
             tr_server._get_packets(
                 tr_server._get_direction_filter(Direction.FROM_SERVER) + " quic"
             )
         )
+        ok_server = self.check_ecn(ecn_server)
+        if ok_server == False:
+            logging.info("Not all server packets were consistently marked with ECT(0) or ECT(1)")
 
-        # This test currently *only* checks that all packets are consistently marked ECT(0) or ECT(1) in each direction
-        # FIXME: We importantly also need to test whether ACK-ECN is being sent in reply
-
-        return self.check_ecn(ecn_client) and self.check_ecn(ecn_server)
+        return ok_client and ok_server
 
 
 class MeasurementGoodput(Measurement):

--- a/testcases.py
+++ b/testcases.py
@@ -778,9 +778,7 @@ class TestCaseECN(TestCaseHandshake):
     def check_ack_ecn(self, tr):
         # NOTE: We only check whether the trace contains any ACK-ECN information, not whether it is valid
         for p in tr:
-            # logging.info(p["quic"])
             if hasattr(p["quic"], "ack.ect0_count"):
-                # logging.info(getattr(p["quic"], "ack.ect0_count"))
                 return True
         return False
 

--- a/testcases.py
+++ b/testcases.py
@@ -22,11 +22,13 @@ class Perspective(Enum):
     SERVER = "server"
     CLIENT = "client"
 
+
 class ECN(IntEnum):
     NONE = 0
     ECT1 = 1
     ECT0 = 2
     CE = 3
+
 
 def random_string(length: int):
     """Generate a random string of fixed length """

--- a/testcases.py
+++ b/testcases.py
@@ -786,8 +786,10 @@ class TestCaseECN(TestCaseHandshake):
             )
         )
         ok_client = self.check_ecn(ecn_client)
-        if ok_client == False:
-            logging.info("Not all client packets were consistently marked with ECT(0) or ECT(1)")
+        if ok_client is False:
+            logging.info(
+                "Not all client packets were consistently marked with ECT(0) or ECT(1)"
+            )
 
         tr_server = self._server_trace()
         ecn_server = self.count_ecn(
@@ -796,8 +798,10 @@ class TestCaseECN(TestCaseHandshake):
             )
         )
         ok_server = self.check_ecn(ecn_server)
-        if ok_server == False:
-            logging.info("Not all server packets were consistently marked with ECT(0) or ECT(1)")
+        if ok_server is False:
+            logging.info(
+                "Not all server packets were consistently marked with ECT(0) or ECT(1)"
+            )
 
         return ok_client and ok_server
 

--- a/testcases.py
+++ b/testcases.py
@@ -759,14 +759,18 @@ class TestCaseECN(TestCaseHandshake):
     def count_ecn(self, tr):
         ecn = [0] * (max(ECN) + 1)
         for p in tr:
-            e = int(getattr(p['ip'], "dsfield.ecn"))
+            e = int(getattr(p["ip"], "dsfield.ecn"))
             ecn[e] += 1
-        for e in (ECN):
+        for e in ECN:
             logging.info("%s %d", e, ecn[e])
         return ecn
 
     def check_ecn(self, e):
-        return e[ECN.NONE] == 0 and e[ECN.CE] == 0 and ((e[ECN.ECT0] == 0) != (e[ECN.ECT1] == 0))
+        return (
+            e[ECN.NONE] == 0
+            and e[ECN.CE] == 0
+            and ((e[ECN.ECT0] == 0) != (e[ECN.ECT1] == 0))
+        )
 
     def check(self):
         if not super(TestCaseECN, self).check():
@@ -775,8 +779,16 @@ class TestCaseECN(TestCaseHandshake):
         tr_client = self._client_trace()
         tr_server = self._server_trace()
 
-        ecn_client = self.count_ecn(tr_client._get_packets(tr_client._get_direction_filter(Direction.FROM_CLIENT) + " quic"))
-        ecn_server = self.count_ecn(tr_server._get_packets(tr_server._get_direction_filter(Direction.FROM_SERVER) + " quic"))
+        ecn_client = self.count_ecn(
+            tr_client._get_packets(
+                tr_client._get_direction_filter(Direction.FROM_CLIENT) + " quic"
+            )
+        )
+        ecn_server = self.count_ecn(
+            tr_server._get_packets(
+                tr_server._get_direction_filter(Direction.FROM_SERVER) + " quic"
+            )
+        )
 
         # This test currently *only* checks that all packets are consistently marked ECT(0) or ECT(1) in each direction
         # FIXME: We importantly also need to test whether ACK-ECN is being sent in reply


### PR DESCRIPTION
This at the moment only checks whether all packets in each direction are consistently marked with ECT(0) or ECT(1). For full compliance we'd also need to test that ACK-ECN frames are sent in response, and ideally also check that ECN validation is correctly implemented (which would likely be a second testcase.)