### PR TITLE
fix passing of upload directory variable

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -115,8 +115,6 @@ jobs:
     needs: [ wireshark, config, docker-pull-tools, docker-pull-images ]
     runs-on: ubuntu-latest
     continue-on-error: true
-    env:
-      LOGNAME: ${{ needs.config.outputs.logname }}
     strategy:
       fail-fast: false
       matrix: 
@@ -188,7 +186,7 @@ jobs:
           username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           source: logs/${{ matrix.server }}_${{ matrix.client }}
-          target: /mnt/logs/$LOGNAME
+          target: /mnt/logs/${{ needs.config.outputs.logname }}
           strip_components: 1
       - name: Upload result
         uses: actions/upload-artifact@v2
@@ -221,7 +219,7 @@ jobs:
           username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           source: result.json
-          target: /mnt/logs/$LOGNAME
+          target: /mnt/logs/${{ needs.config.outputs.logname }}
       - name: Publish result
         if: ${{ github.event_name == 'schedule' }}
         uses: appleboy/ssh-action@master
@@ -229,7 +227,8 @@ jobs:
           host: interop.seemann.io
           username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
+          envs: LOGNAME
           script: |
             cd /mnt/logs
-            jq '. += [ "$LOGNAME" ]' logs.json | sponge logs.json
+            jq '. += [ "${{ needs.config.outputs.logname }}" ]' logs.json | sponge logs.json
             rm latest && ln -s $LOGNAME latest


### PR DESCRIPTION
Turns out that GitHub actions doesn't evaluate the environment variables quite the way I expected, which resulted in logs being uploaded to the wrong directory.