### PR TITLE
Make mounts delegated, which has some minor speed benefits on Mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - $WWW:/www
+      - $WWW:/www:delegated
     environment:
       - CRON=$CRON
       - ROLE=server
@@ -51,7 +51,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - $DOWNLOADS:/downloads
+      - $DOWNLOADS:/downloads:delegated
     environment:
       - CRON=$CRON
       - ROLE=client


### PR DESCRIPTION
See https://docs.docker.com/compose/compose-file/#caching-options-for-volume-mounts-docker-desktop-for-mac