### PR TITLE
fix invocation of isort on CI

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -3,7 +3,7 @@
 set -ex
 
 flake8 .
-isort -c -df .
+isort --check --diff .
 black --check --diff .
 
 # test that we can parse implementations.json


### PR DESCRIPTION
Apparently version 5 of isort changed the command line flags.