### PR TITLE
add a key update test

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Currently disabled due to #20.
 
 * **ChaCha20** (`chacha20`, only for the client): In this test, the client is expected to offer **only** ChaCha20 as a ciphersuite, and download the files.
 
+* **KeyUpdate** (`keyupdate`, only for the client): The client is expected to make sure that a key update happens early in the connection (during the first MB transferred). It doesn't matter which peer actually initiated the update.
+
 * **Retry** (`retry`): Tests that the server can generate a Retry, and that the client can act upon it (i.e. use the Token provided in the Retry packet in the Initial packet).
 
 * **Resumption** (`resumption`): Tests QUIC session resumption (without 0-RTT). The client is expected to establish a connection and download the first file. The server is expected to provide the client with a session ticket that allows it to resume the connection. After downloading the first file, the client has to close the connection, establish a resumed connection using the session ticket, and use this connection to download the remaining file(s).

--- a/interop.py
+++ b/interop.py
@@ -10,13 +10,13 @@ import subprocess
 import sys
 import tempfile
 from datetime import datetime
-from enum import Enum
 from typing import Callable, List, Tuple
 
 import prettytable
 from termcolor import colored
 
 import testcases
+from result import TestResult
 from testcases import Perspective
 
 
@@ -24,12 +24,6 @@ def random_string(length: int):
     """ Generate a random string of fixed length """
     letters = string.ascii_lowercase
     return "".join(random.choice(letters) for i in range(length))
-
-
-class TestResult(Enum):
-    SUCCEEDED = "succeeded"
-    FAILED = "failed"
-    UNSUPPORTED = "unsupported"
 
 
 class MeasurementResult:
@@ -384,8 +378,7 @@ class InteropRunner:
             if self._is_unsupported(lines):
                 status = TestResult.UNSUPPORTED
             elif any("client exited with code 0" in str(line) for line in lines):
-                if testcase.check():
-                    status = TestResult.SUCCEEDED
+                status = testcase.check()
 
         # save logs
         logging.getLogger().removeHandler(log_handler)

--- a/result.py
+++ b/result.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class TestResult(Enum):
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    UNSUPPORTED = "unsupported"

--- a/testcases.py
+++ b/testcases.py
@@ -409,6 +409,9 @@ class TestCaseMultiplexing(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        if not self._keylog_file():
+            logging.info("Can't check test result. SSLKEYLOG required.")
+            return TestResult.UNSUPPORTED
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -428,9 +431,8 @@ class TestCaseMultiplexing(TestCase):
                     logging.info("Server set a stream limit > 1000.")
                     return TestResult.FAILED
         if not checked_stream_limit:
-            logging.debug(
-                "WARNING: Couldn't check stream limit. No SSLKEYLOG file available?"
-            )
+            logging.info("Couldn't check stream limit.")
+            return TestResult.FAILED
         return TestResult.SUCCEEDED
 
 

--- a/testcases.py
+++ b/testcases.py
@@ -684,11 +684,17 @@ class TestCaseKeyUpdate(TestCaseHandshake):
             return TestResult.FAILED
 
         client = {0: 0, 1: 0}
-        for p in self._client_trace().get_1rtt(Direction.FROM_CLIENT):
-            client[int(p.key_phase)] += 1
         server = {0: 0, 1: 0}
-        for p in self._server_trace().get_1rtt(Direction.FROM_SERVER):
-            server[int(p.key_phase)] += 1
+        try:
+            for p in self._client_trace().get_1rtt(Direction.FROM_CLIENT):
+                client[int(p.key_phase)] += 1
+            for p in self._server_trace().get_1rtt(Direction.FROM_SERVER):
+                server[int(p.key_phase)] += 1
+        except Exception:
+            logging.info(
+                "Failed to read key phase bits. Potentially incorrect SSLKEYLOG?"
+            )
+            return TestResult.FAILED
 
         succeeded = client[0] * client[1] * server[0] * server[1] > 0
 


### PR DESCRIPTION
Fixes #95. 

This tests presents itself as "keyupdate" to the client and as "transfer" to the server.

The client is expected to make sure that a key update happens (although it is not *required* to initiate it, if the server initiates the key update, that's fine too). Test verification looks at the decrypted PCAP and checks that both client and server sent at least one packet in key phase 0 and one packet in key phase 1.
If no SSLKEYLOG is available (as is the case in the mvfst - mvfst tests), the test status is report as "unsupported". I also changed the multiplexing test to behave analogously.