### PR TITLE
disable tshark HTTP/3 support as a workaround for slow trace processing

### DIFF
--- a/trace.py
+++ b/trace.py
@@ -35,6 +35,7 @@ class TraceAnalyzer:
             self._filename,
             display_filter=f,
             override_prefs=override_prefs,
+            disable_protocol="http3",  # see https://github.com/marten-seemann/quic-interop-runner/pull/179/
             decode_as={"udp.port==443": "quic"},
         )
         packets = []


### PR DESCRIPTION
Some runs of the interop runner take insanely long, e.g. this picoquic - quiche run took more than 1.5 hours: https://github.com/marten-seemann/quic-interop-runner/runs/1095324523?check_suite_focus=true

It turns out that trace parsing is the culprit here. For some traces, parsing the last packet of a stream takes around 2 minutes on my machine. Here's a minimal example generated from a picoquic - quiche run: 
[Archive (3).zip](https://github.com/marten-seemann/quic-interop-runner/files/5201726/Archive.3.zip)

Disabling HTTP/3 support in tshark seems to solve this problem. As we're currently not parsing HTTP/3 frames at all, this is an easy workaround.
