### PR TITLE
add Chrome (HTTP/3-only)

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -63,5 +63,10 @@
     "image": "pquic/pquic-interop:latest",
     "url": "https://pquic.org/",
     "role": "both"
+  },
+  "chrome": {
+    "image": "martenseemann/chrome-quic-interop-runner",
+    "url": "https://github.com/marten-seemann/chrome-quic-interop-runner",
+    "role": "client"
   }
 }


### PR DESCRIPTION
It's not easy to convince Chrome Headless to download files to disk: https://github.com/marten-seemann/chrome-quic-interop-runner.

The test will only succeed if implementations use the certificate chain provided by the interop runner (#194).