### PR TITLE
generate a new certificate chain for every test

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -193,8 +193,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -r requirements.txt
-      - name: Generate certificates
-        run: ./certs.sh
       - name: Run tests
         env:
           CRON: "true"

--- a/certs.sh
+++ b/certs.sh
@@ -12,22 +12,22 @@ CERTDIR=$1
 
 mkdir -p $CERTDIR || true
 
-echo "Generating CA key and certificate:"
+# Generate CA key and certificate
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
   -keyout $CERTDIR/ca.key -out $CERTDIR/ca.pem \
-  -subj "/O=interop runner Certificate Authority/"
+  -subj "/O=interop runner Certificate Authority/" \
+  2> /dev/null
 
-echo "Generating CSR"
+# Create a CSR
 openssl req -out $CERTDIR/cert.csr -new -newkey rsa:2048 -nodes -keyout $CERTDIR/priv.key \
-  -subj "/O=interop runner/"
+  -subj "/O=interop runner/" \
+  2> /dev/null
 
-echo "Sign certificate:"
+# Sign the certificate
 openssl x509 -req -sha256 -days 365 -in $CERTDIR/cert.csr -out $CERTDIR/cert.pem \
   -CA $CERTDIR/ca.pem -CAkey $CERTDIR/ca.key -CAcreateserial \
-  -extfile <(printf "subjectAltName=DNS:server")
-
-# debug output the certificate
-openssl x509 -noout -text -in $CERTDIR/cert.pem
+  -extfile <(printf "subjectAltName=DNS:server") \
+  2> /dev/null
 
 # we don't need the CA key, the serial number and the CSR any more
 rm $CERTDIR/ca.key $CERTDIR/cert.csr $CERTDIR/ca.srl

--- a/certs.sh
+++ b/certs.sh
@@ -2,7 +2,13 @@
 
 set -e
 
-CERTDIR="certs"
+if [ -z $1 ]; then
+  echo "$0 <cert dir>"
+  exit 1
+fi
+
+CERTDIR=$1
+
 
 mkdir -p $CERTDIR || true
 

--- a/interop.py
+++ b/interop.py
@@ -117,13 +117,7 @@ class InteropRunner:
             dir="/tmp", prefix="compliance_downloads_"
         )
 
-        output = subprocess.run(
-            "./certs.sh " + certs_dir.name,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-        logging.debug("%s", output.stdout.decode("utf-8"))
+        testcases.generate_cert_chain(certs_dir.name)
 
         # check that the client is capable of returning UNSUPPORTED
         logging.debug("Checking compliance of %s client", name)

--- a/testcases.py
+++ b/testcases.py
@@ -4,6 +4,7 @@ import logging
 import os
 import random
 import string
+import subprocess
 import tempfile
 from datetime import timedelta
 from enum import Enum, IntEnum
@@ -46,6 +47,7 @@ class TestCase(abc.ABC):
     _server_keylog_file = None
     _download_dir = None
     _sim_log_dir = None
+    _cert_dir = None
 
     def __init__(
         self,
@@ -102,6 +104,16 @@ class TestCase(abc.ABC):
                 dir="/tmp", prefix="download_"
             )
         return self._download_dir.name + "/"
+
+    def certs_dir(self):
+        if not self._cert_dir:
+            self._cert_dir = tempfile.TemporaryDirectory(dir="/tmp", prefix="certs_")
+            cmd = "./certs.sh " + self._cert_dir.name
+            output = subprocess.run(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            logging.debug("%s", output.stdout.decode("utf-8"))
+        return self._cert_dir.name + "/"
 
     def _keylog_file(self) -> str:
         if os.path.isfile(self._client_keylog_file):


### PR DESCRIPTION
The certificate chain will be generated in a temporary directory, so people won't have to run `certs.sh` manually any more.