### PR TITLE
add a test case for the amplification limit

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -3,7 +3,7 @@
 set -ex
 
 flake8 .
-isort --check --diff .
+isort -l 100 --check --diff .
 black --check --diff .
 
 # test that we can parse implementations.json

--- a/certs.sh
+++ b/certs.sh
@@ -2,33 +2,58 @@
 
 set -e
 
-if [ -z $1 ]; then
-  echo "$0 <cert dir>"
+if [ -z "$1" ] || [ -z "$2" ] ; then
+  echo "$0 <cert dir> <chain length>"
   exit 1
 fi
 
 CERTDIR=$1
-
+CHAINLEN=$2
 
 mkdir -p $CERTDIR || true
 
-# Generate CA key and certificate
+# Generate Root CA and certificate
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
-  -keyout $CERTDIR/ca.key -out $CERTDIR/ca.pem \
-  -subj "/O=interop runner Certificate Authority/" \
+  -keyout $CERTDIR/ca_0.key -out $CERTDIR/cert_0.pem \
+  -subj "/O=interop runner Root Certificate Authority/" \
+  -config config.txt \
+  -extensions v3_ca \
   2> /dev/null
 
-# Create a CSR
-openssl req -out $CERTDIR/cert.csr -new -newkey rsa:2048 -nodes -keyout $CERTDIR/priv.key \
-  -subj "/O=interop runner/" \
-  2> /dev/null
+for i in $(seq 1 $CHAINLEN); do
+  # Generate a CSR
+  SUBJ="interop runner intermediate $i"
+  if [[ $i == $CHAINLEN ]]; then
+    SUBJ="interop runner leaf"
+  fi
+  openssl req -out $CERTDIR/cert.csr -new -newkey rsa:2048 -nodes -keyout $CERTDIR/ca_$i.key \
+    -subj "/O=$SUBJ/" \
+    2> /dev/null
 
-# Sign the certificate
-openssl x509 -req -sha256 -days 365 -in $CERTDIR/cert.csr -out $CERTDIR/cert.pem \
-  -CA $CERTDIR/ca.pem -CAkey $CERTDIR/ca.key -CAcreateserial \
-  -extfile <(printf "subjectAltName=DNS:server") \
-  2> /dev/null
+  # Sign the certificate
+  j=$(($i-1))
+  if [[ $i < $CHAINLEN ]]; then
+    openssl x509 -req -sha256 -days 365 -in $CERTDIR/cert.csr -out $CERTDIR/cert_$i.pem \
+      -CA $CERTDIR/cert_$j.pem -CAkey $CERTDIR/ca_$j.key -CAcreateserial \
+      -extfile config.txt \
+      -extensions v3_ca \
+      2> /dev/null
+  else
+    openssl x509 -req -sha256 -days 365 -in $CERTDIR/cert.csr -out $CERTDIR/cert_$i.pem \
+      -CA $CERTDIR/cert_$j.pem -CAkey $CERTDIR/ca_$j.key -CAcreateserial \
+      -extfile <(printf "subjectAltName=DNS:server") \
+      2> /dev/null
+  fi
+done
 
-# we don't need the CA key, the serial number and the CSR any more
-rm $CERTDIR/ca.key $CERTDIR/cert.csr $CERTDIR/ca.srl
+mv $CERTDIR/cert_0.pem $CERTDIR/ca.pem
+cp $CERTDIR/ca_$CHAINLEN.key $CERTDIR/priv.key
+
+# combine certificates
+for i in $(seq $CHAINLEN 1); do
+  cat $CERTDIR/cert_$i.pem >> $CERTDIR/cert.pem
+  rm $CERTDIR/cert_$i.pem $CERTDIR/ca_$i.key
+done
+rm $CERTDIR/*.srl $CERTDIR/ca_0.key $CERTDIR/cert.csr
+
 

--- a/testcases.py
+++ b/testcases.py
@@ -42,7 +42,7 @@ def random_string(length: int):
 
 
 def generate_cert_chain(directory: str):
-    cmd = "./certs.sh " + directory
+    cmd = "./certs.sh " + directory + " 1"
     r = subprocess.run(
         cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )

--- a/trace.py
+++ b/trace.py
@@ -49,6 +49,12 @@ class TraceAnalyzer:
             logging.debug(e)
         return packets
 
+    def get_raw_packets(self, direction: Direction = Direction.ALL) -> List:
+        packets = []
+        for packet in self._get_packets(self._get_direction_filter(direction) + "quic"):
+            packets.append(packet)
+        return packets
+
     def get_1rtt(self, direction: Direction = Direction.ALL) -> List:
         """ Get all QUIC packets, one or both directions. """
         packets = []


### PR DESCRIPTION
cc @larseggert 

Depends on #196.

I already heard that some implementations ignore the MUST in the spec and send 3.x * what the client sent (e.g. quicly). We might want to relax the test here a bit, if we want to accommodate those implementations. Or we might call them out for violating the spec.