### PR TITLE
avoid --abort-on-container-exit to allow containers to react to SIGTERM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,12 +31,9 @@ services:
     environment:
       - CRON=$CRON
       - ROLE=server
-      - SERVER_PARAMS=$SERVER_PARAMS
       - SSLKEYLOGFILE=/logs/keys.log
       - QLOGDIR=/logs/qlog/
       - TESTCASE=$TESTCASE_SERVER
-    depends_on:
-      - sim
     cap_add: 
       - NET_ADMIN
     ulimits:
@@ -44,6 +41,9 @@ services:
     networks:
       rightnet:
         ipv4_address: 193.167.100.100
+    extra_hosts:
+      - "sim:193.167.100.2"
+      - "client:193.167.0.100"
 
   client:
     image: $CLIENT
@@ -57,13 +57,10 @@ services:
     environment:
       - CRON=$CRON
       - ROLE=client
-      - CLIENT_PARAMS=$CLIENT_PARAMS
       - SSLKEYLOGFILE=/logs/keys.log
       - QLOGDIR=/logs/qlog/
       - TESTCASE=$TESTCASE_CLIENT
       - REQUESTS=$REQUESTS
-    depends_on:
-      - sim
     cap_add: 
       - NET_ADMIN
     ulimits:
@@ -72,6 +69,7 @@ services:
       leftnet:
         ipv4_address: 193.167.0.100
     extra_hosts:
+      - "sim:193.167.0.2"
       - "server:193.167.100.100"
   
   iperf_server:
@@ -81,8 +79,6 @@ services:
     tty: true
     environment:
       - ROLE=server
-    depends_on:
-      - sim
     cap_add: 
       - NET_ADMIN
     networks:
@@ -98,8 +94,6 @@ services:
     tty: true
     environment:
       - ROLE=client
-    depends_on:
-      - sim
     cap_add: 
       - NET_ADMIN
     networks:

--- a/docker.py
+++ b/docker.py
@@ -1,0 +1,91 @@
+import io
+import logging
+import shutil
+import subprocess
+import threading
+
+
+class DockerRunner:
+    _containers = None
+    _cond = None
+    _timeout = 0  # in seconds
+    _expired = False
+
+    def __init__(self, timeout: int):
+        self._containers = []
+        self._cond = threading.Condition()
+        self._timeout = timeout
+
+    def add_container(self, name: str, env: dict):
+        self._containers.append({"name": name, "env": env})
+
+    def _run_container(self, cmd: str, env: dict, name: str):
+        self._execute(cmd, env, name)
+        with self._cond:
+            logging.debug("%s container returned.", name)
+            self._cond.notify()
+
+    def _execute(self, cmd: str, env: dict = {}, name: str = ""):
+        p = subprocess.Popen(
+            cmd.split(" "),
+            bufsize=1,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        for line in p.stdout:
+            ll = ""
+            if name:
+                ll = name + ": "
+            ll = ll + line.rstrip()
+            logging.debug(ll)
+
+    def _run_timer(self):
+        logging.debug("Timer expired. Stopping all containers.")
+        self._expired = True
+        with self._cond:
+            self._cond.notify()
+
+    def run(self) -> (str, bool):  # returns if the timer expired
+        # also log to a string, so we can parse the output later
+        output_string = io.StringIO()
+        output_stream = logging.StreamHandler(output_string)
+        output_stream.setLevel(logging.DEBUG)
+        logging.getLogger().addHandler(output_stream)
+
+        threads = []
+        # Start all containers (in separate threads)
+        docker_compose = shutil.which("docker-compose")
+        for e in self._containers:
+            t = threading.Thread(
+                target=self._run_container,
+                kwargs={
+                    "cmd": docker_compose + " up " + e["name"],
+                    "env": e["env"],
+                    "name": e["name"],
+                },
+            )
+            t.start()
+            threads.append(t)
+        # set a timer
+        timer = threading.Timer(self._timeout, self._run_timer)
+        timer.start()
+
+        # Wait for the first container to exit.
+        # Then stop all other docker containers.
+        with self._cond:
+            self._cond.wait()
+            names = [x["name"] for x in self._containers]
+            self._execute(
+                shutil.which("docker-compose") + " stop -t 5 " + " ".join(names)
+            )
+        # wait for all threads to finish
+        for t in threads:
+            t.join()
+        timer.cancel()
+
+        output = output_string.getvalue()
+        output_string.close()
+        logging.getLogger().removeHandler(output_stream)
+        return output, self._expired

--- a/testcases.py
+++ b/testcases.py
@@ -85,11 +85,11 @@ class TestCase(abc.ABC):
 
     @staticmethod
     def additional_envs() -> List[str]:
-        return [""]
+        return []
 
     @staticmethod
     def additional_containers() -> List[str]:
-        return [""]
+        return []
 
     def www_dir(self):
         if not self._www_dir:
@@ -1080,8 +1080,8 @@ class MeasurementCrossTraffic(MeasurementGoodput):
         return 180
 
     @staticmethod
-    def additional_envs() -> List[str]:
-        return ["IPERF_CONGESTION=cubic"]
+    def additional_envs() -> dict:
+        return {"IPERF_CONGESTION": "cubic"}
 
     @staticmethod
     def additional_containers() -> List[str]:


### PR DESCRIPTION
Fixes #131. cc @nibanks 