### PR TITLE
improve error message for invalid test case names

### DIFF
--- a/run.py
+++ b/run.py
@@ -107,7 +107,18 @@ def main():
             elif t in [tc.name() for tc in MEASUREMENTS]:
                 measurements += [tc for tc in MEASUREMENTS if tc.name() == t]
             else:
-                sys.exit("Test case " + t + " not found.")
+                print(
+                    (
+                        "Test case {} not found.\n"
+                        "Avaiable testcases: {}\n"
+                        "Available measurements: {}"
+                    ).format(
+                        t,
+                        ", ".join([t.name() for t in TESTCASES]),
+                        ", ".join([t.name() for t in MEASUREMENTS]),
+                    )
+                )
+                sys.exit()
         return tests, measurements
 
     t = get_tests_and_measurements(get_args().test)


### PR DESCRIPTION
```
❯ python3 run.py -t invalid
Test case invalid not found.
Avaiable testcases: handshake, transfer, longrtt, chacha20, multiplexing, retry, resumption, zerortt, http3, blackhole, keyupdate, ecn, handshakeloss, transferloss, handshakecorruption, transfercorruption, rebind-port, rebind-addr
Available measurements: goodput, crosstraffic
```