### PR TITLE
fix generating of long certificate chains on Linux

### DIFF
--- a/certs.sh
+++ b/certs.sh
@@ -50,7 +50,7 @@ mv $CERTDIR/cert_0.pem $CERTDIR/ca.pem
 cp $CERTDIR/ca_$CHAINLEN.key $CERTDIR/priv.key
 
 # combine certificates
-for i in $(seq $CHAINLEN 1); do
+for i in $(seq $CHAINLEN -1 1); do
   cat $CERTDIR/cert_$i.pem >> $CERTDIR/cert.pem
   rm $CERTDIR/cert_$i.pem $CERTDIR/ca_$i.key
 done


### PR DESCRIPTION
Turns out that `seq 9 1` on OSX gives you the numbers from 9 to 1 (in descending order), whereas the same command returns and empty output on Linux.