### PR TITLE
use chacha20 as test name for the ChaCha20 test for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Currently disabled due to #20.
 
 * **Transfer** (`transfer`): Tests both flow control and stream multiplexing. The client should use small initial flow control windows for both stream- and connection-level flow control, such that the during the transfer of files on the order of 1 MB the flow control window needs to be increased. The client is exepcted to establish a single QUIC connection, and use multiple streams to concurrently download the files.
 
-* **ChaCha20** (`chacha20`, only for the client): In this test, the client is expected to offer **only** ChaCha20 as a ciphersuite, and download the files.
+* **ChaCha20** (`chacha20`): In this test, client and server are expected to offer **only** ChaCha20 as a ciphersuite. The client then downloads the files.
 
 * **KeyUpdate** (`keyupdate`, only for the client): The client is expected to make sure that a key update happens early in the connection (during the first MB transferred). It doesn't matter which peer actually initiated the update.
 

--- a/testcases.py
+++ b/testcases.py
@@ -416,9 +416,7 @@ class TestCaseChaCha20(TestCase):
 
     @staticmethod
     def testname(p: Perspective):
-        if p is Perspective.CLIENT:
-            return "chacha20"
-        return "transfer"
+        return "chacha20"
 
     @staticmethod
     def abbreviation():


### PR DESCRIPTION
CAUTION: This is a breaking change. Server implementations will (probably) have to be updated

mvfst doesn't support ChaCha20 header protection, and therefore this test always fails.

cc @martinthomson @mjoras