### PR TITLE
allow up to 3.x amplification in the amplification limit test

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -764,7 +764,7 @@ class TestCaseAmplificationLimit(TestCase):
             "Server sent %d bytes in Handshake CRYPTO frames.", max_handshake_offset
         )
 
-        # Check that the server didn't send more than 3.x* what the client sent.
+        # Check that the server didn't send more than 3-4x what the client sent.
         allowed = 0
         allowed_with_tolerance = 0
         client_sent, server_sent = 0, 0  # only for debug messages
@@ -805,7 +805,7 @@ class TestCaseAmplificationLimit(TestCase):
                     break
                 if packet_size > allowed:
                     log_output.append(
-                        "Server violated the amplification limit, but stayed below 3.x amplification. Letting it slide."
+                        "Server violated the amplification limit, but stayed within 3-4x amplification. Letting it slide."
                     )
                 allowed_with_tolerance -= packet_size
                 allowed -= packet_size


### PR DESCRIPTION
Many implementations implement a 3.x amplification limit instead of a 3x amplification limit. This seems a reasonable thing to do, as it achieves a limit of the amplification factor, and 3 is an arbitrary value anyway.
I'm aware that this PR will make the people who argue that the interop runner should test _exactly_ what the spec says unhappy. There's no way to satisfy both.