### PR TITLE
Don't just check the first line for a match

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -135,7 +135,7 @@ class TestCase(abc.ABC):
         if not os.path.isfile(filename):
             return False
         with open(filename, "r") as file:
-            if not re.search(r"^SERVER_HANDSHAKE_TRAFFIC_SECRET", file.read()):
+            if not re.search(r"^SERVER_HANDSHAKE_TRAFFIC_SECRET", file.read(), re.M):
                 logging.info("Key log file %s is using incorrect format.", filename)
                 return False
         return True

--- a/testcases.py
+++ b/testcases.py
@@ -135,7 +135,9 @@ class TestCase(abc.ABC):
         if not os.path.isfile(filename):
             return False
         with open(filename, "r") as file:
-            if not re.search(r"^SERVER_HANDSHAKE_TRAFFIC_SECRET", file.read(), re.M):
+            if not re.search(
+                r"^SERVER_HANDSHAKE_TRAFFIC_SECRET", file.read(), re.MULTILINE
+            ):
                 logging.info("Key log file %s is using incorrect format.", filename)
                 return False
         return True


### PR DESCRIPTION
Otherwise keylogs that use a comment or something else in the first line are erroneously rejected as invalid.