### PR TITLE
Now that wireshark has fewer bugs, don't blame it.

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -7,7 +7,7 @@ on:
 # To trigger a rebuild of Wireshark increment this value.
 # The rebuild will then build the current master of Wireshark and save it under the new key.
 env:
-  WIRESHARK_CACHEKEY: 2
+  WIRESHARK_CACHEKEY: 3
 
 jobs:
   wireshark:

--- a/trace.py
+++ b/trace.py
@@ -104,10 +104,8 @@ class TraceAnalyzer:
         if self._keylog_file is not None:
             for p in packets:
                 if hasattr(p["quic"], "decryption_failed"):
-                    logging.info(
-                        "At least one QUIC packet could not be decrypted; wireshark bug?"
-                    )
-                    logging.info(p)
+                    logging.info("At least one QUIC packet could not be decrypted")
+                    logging.debug(p)
                     break
         return packets
 


### PR DESCRIPTION
And log the details of undecryptable packets to the debug log only.