### PR TITLE
Update MsQuic to GitHub Registry

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -55,7 +55,7 @@
     "role": "server"
   },
   "msquic": {
-    "image": "mcr.microsoft.com/msquic/qns:latest",
+    "image": "ghcr.io/microsoft/msquic/qns:main",
     "url": "https://github.com/microsoft/msquic",
     "role": "both"
   },


### PR DESCRIPTION
Point to the new location for MsQuic, on the GitHub registry. Also uses the tag `main` instead of `latest`. cc @anrossi @thhous-msft