### PR TITLE
Fix ChaCha20 test failed when returned 0x1303

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -456,7 +456,7 @@ class TestCaseChaCha20(TestCase):
         for p in self._client_trace().get_initial(Direction.FROM_CLIENT):
             if hasattr(p, "tls_handshake_ciphersuite"):
                 ciphersuites.append(p.tls_handshake_ciphersuite)
-        if len(set(ciphersuites)) != 1 or ciphersuites[0] != "4867":
+        if len(set(ciphersuites)) != 1 or ciphersuites[0] != "4867" or ciphersuites[0] != "0x1303":
             logging.info(
                 "Expected only ChaCha20 cipher suite to be offered. Got: %s",
                 set(ciphersuites),


### PR DESCRIPTION
`0x1303` equals to `4867`. However, some platforms such as nginx-quic who returned `0x1303` instead are treated as failure:
> python3 run.py -s nginx -c neqo -t chacha20

then get:
> Expected only ChaCha20 cipher suite to be offered. Got: {'0x1303'}

Fix now.