### PR TITLE
add s2n-quic implementation

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -85,7 +85,7 @@
     "role": "both"
   },
   "s2n-quic": {
-    "image": "public.ecr.aws/y1p7y6w8/s2n-quic-qns:latest",
+    "image": "public.ecr.aws/s2n/s2n-quic-qns:latest",
     "url": "https://github.com/aws/s2n-quic",
     "role": "both"
   }

--- a/implementations.json
+++ b/implementations.json
@@ -83,5 +83,10 @@
     "image": "stammw/quinn-interop:latest",
     "url": "https://github.com/quinn-rs/quinn",
     "role": "both"
+  },
+  "s2n-quic": {
+    "image": "public.ecr.aws/y1p7y6w8/s2n-quic-qns:latest",
+    "url": "https://github.com/aws/s2n-quic",
+    "role": "both"
   }
 }


### PR DESCRIPTION
This change adds [s2n-quic](https://github.com/aws/s2n-quic) to the list of implementations