### PR TITLE
Add v2 testcase

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -7,7 +7,7 @@ on:
 # To trigger a rebuild of Wireshark increment this value.
 # The rebuild will then build the current master of Wireshark and save it under the new key.
 env:
-  WIRESHARK_CACHEKEY: 4
+  WIRESHARK_CACHEKEY: 5
 
 jobs:
   wireshark:

--- a/README.md
+++ b/README.md
@@ -82,3 +82,5 @@ Currently disabled due to #20.
 * **HTTP3** (`http3`): Tests a simple HTTP/3 connection. The client is expected to download multiple files using HTTP/3. Files should be requested and transfered in parallel.
 
 * **Handshake Loss** (`multiconnect`): Tests resilience of the handshake to high loss. The client is expected to establish multiple connections, sequential or in parallel, and use each connection to download a single file.
+
+* **V2** (`v2`): In this test, client starts connecting server in QUIC v1 with `version_information` transport parameter that includes QUIC v2 (`0x709a50c4`) in `other_versions` field.  Server should select QUIC v2 in compatible version negotiation.  Client is expected to download one small file in QUIC v2.

--- a/trace.py
+++ b/trace.py
@@ -10,6 +10,9 @@ IP6_CLIENT = "fd00:cafe:cafe:0::100"
 IP6_SERVER = "fd00:cafe:cafe:100::100"
 
 
+QUIC_V2_DRAFT = hex(0x709a50c4)
+
+
 class Direction(Enum):
     ALL = 0
     FROM_CLIENT = 1
@@ -35,6 +38,14 @@ WIRESHARK_PACKET_TYPES = {
 }
 
 
+WIRESHARK_PACKET_TYPES_V2_DRAFT = {
+    PacketType.INITIAL: "1",
+    PacketType.ZERORTT: "2",
+    PacketType.HANDSHAKE: "3",
+    PacketType.RETRY: "0",
+}
+
+
 def get_direction(p) -> Direction:
     if (hasattr(p, "ip") and p.ip.src == IP4_CLIENT) or (
         hasattr(p, "ipv6") and p.ipv6.src == IP6_CLIENT
@@ -54,6 +65,11 @@ def get_packet_type(p) -> PacketType:
         return PacketType.ONERTT
     if p.quic.version == "0x00000000":
         return PacketType.VERSIONNEGOTIATION
+    if p.quic.version == QUIC_V2_DRAFT:
+        for t, num in WIRESHARK_PACKET_TYPES_V2_DRAFT.items():
+            if p.quic.long_packet_type_v2 == num:
+                return t
+        return PacketType.INVALID
     for t, num in WIRESHARK_PACKET_TYPES.items():
         if p.quic.long_packet_type == num:
             return t
@@ -124,6 +140,8 @@ class TraceAnalyzer:
             for layer in packet.layers:
                 if layer.layer_name == "quic" and not hasattr(
                     layer, "long_packet_type"
+                ) and not hasattr(
+                    layer, "long_packet_type_v2"
                 ):
                     layer.sniff_time = packet.sniff_time
                     packets.append(layer)
@@ -139,13 +157,22 @@ class TraceAnalyzer:
     ) -> List:
         packets = []
         for packet in self._get_packets(
-            self._get_direction_filter(direction) + "quic.long.packet_type"
+            self._get_direction_filter(direction) +
+                "(quic.long.packet_type || quic.long.packet_type_v2)"
         ):
             for layer in packet.layers:
                 if (
                     layer.layer_name == "quic"
-                    and hasattr(layer, "long_packet_type")
-                    and layer.long_packet_type == WIRESHARK_PACKET_TYPES[packet_type]
+                    and (
+                        (
+                            hasattr(layer, "long_packet_type")
+                            and layer.long_packet_type == WIRESHARK_PACKET_TYPES[packet_type]
+                        )
+                        or (
+                            hasattr(layer, "long_packet_type_v2")
+                            and layer.long_packet_type_v2 == WIRESHARK_PACKET_TYPES_V2_DRAFT[packet_type]
+                        )
+                    )
                 ):
                     packets.append(layer)
         return packets


### PR DESCRIPTION
This PR adds a test case which asserts that client and server negotiate QUIC v2 draft version using compatible version negotiation.
When wireshark gets support of latest version_information transport parameter, it would be nice to add a check for chosen_version field.

wireshark cache key is updated to bring wireshark which supports QUIC v2 draft.
