### PR TITLE
Fix `Preference "ssl.keylog_file" has been converted to "tls.keylog_file"`

### DIFF
--- a/trace.py
+++ b/trace.py
@@ -99,7 +99,7 @@ class TraceAnalyzer:
     def _get_packets(self, f: str) -> List:
         override_prefs = {}
         if self._keylog_file is not None:
-            override_prefs["ssl.keylog_file"] = self._keylog_file
+            override_prefs["tls.keylog_file"] = self._keylog_file
         cap = pyshark.FileCapture(
             self._filename,
             display_filter=f,


### PR DESCRIPTION
When `cap.set_debug()` is set on the pyshark capture object, tshark prints the warning:

> ** (tshark:810515) 11:02:35.574079 [Epan WARNING] epan/prefs.c:5570 -- set_pref(): Preference "ssl.keylog_file" has been converted to "tls.keylog_file"

This MR fixes it.