### PR TITLE
Update NGINX to Amazon Registry

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -45,7 +45,7 @@
     "role": "both"
   },
   "nginx": {
-    "image": "nginx/nginx-quic-qns:latest",
+    "image": "public.ecr.aws/nginx/nginx-quic-qns:latest",
     "url": "https://quic.nginx.org/",
     "role": "server"
   },


### PR DESCRIPTION
NGINX QUIC interop image has moved to Amazon ECR Public registry. cc @thresheek @vl-homutov