### PR TITLE
replaced pycrypto dependency by pycryptodome, because pycrypto is not…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycrypto
+pycryptodome
 termcolor
 prettytable
 pyshark


### PR DESCRIPTION
… maintained anymore and doesn't work with python3