### PR TITLE
Fix longrtt

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -391,6 +391,10 @@ class TestCaseLongRTT(TestCaseHandshake):
             if hasattr(p, "tls_handshake_type"):
                 if p.tls_handshake_type == "1":
                     num_ch += 1
+            # Retransmitted ClientHello does not have
+            # tls_handshake_type attribute.  See
+            # https://gitlab.com/wireshark/wireshark/-/issues/18696
+            # for details.
             elif hasattr(p, "retransmission") or hasattr(p, "overlap"):
                 num_ch += 1
         if num_ch < 2:

--- a/testcases.py
+++ b/testcases.py
@@ -391,6 +391,8 @@ class TestCaseLongRTT(TestCaseHandshake):
             if hasattr(p, "tls_handshake_type"):
                 if p.tls_handshake_type == "1":
                     num_ch += 1
+            elif hasattr(p, "retransmission") or hasattr(p, "overlap"):
+                num_ch += 1
         if num_ch < 2:
             logging.info("Expected at least 2 ClientHellos. Got: %d", num_ch)
             return TestResult.FAILED


### PR DESCRIPTION
Wireshark now does not add "tls_handshake_type" attribute to a retransmitted Initial packets which contain CRYPTO frame.  Instead, it adds either "retransmission" or "overlap" attribute.  Consider these attributes as a sign of retransmission of ClientHello.

See https://gitlab.com/wireshark/wireshark/-/issues/18696 for details.