### PR TITLE
Add NET_RAW capability to the quic-network-simulator container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - SCENARIO=$SCENARIO
     cap_add: 
       - NET_ADMIN
+      - NET_RAW
     expose:
       - "57832"
     networks:


### PR DESCRIPTION
When experimenting with non-root `podman` (a replacement for `docker`), the network-simulator container named `sim` when launched, runs into exception and the tests fail with:

```
Creating sim ... 
Creating sim ... done
Creating client ... 
Creating client ... done
Attaching to sim, client
sim             | Using scenario: simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25
sim             | ../src/fd-net-device/helper/raw-sock-creator.cc: fatal error at line 86: main(): CreateSocket(): Unable to open raw socket
sim             |     errno = 1 (Operation not permitted)
sim             | msg="EmuFdNetDeviceHelper::CreateFileDescriptor(): socket creator exited normally with status 255", +0.000000000s -1 file=../src/fd-net-device/helper/emu-fd-net-device-helper.cc, line=335
sim             | terminate called without an active exception
sim             | /ns3/./run.sh: line 31:     8 Aborted                 (core dumped) ./scratch/simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25
...
sim exited with code 0
```
It appears that the container attempts to create a raw socket and fails with permission errors.

The commit in this PR adds `NET_RAW` capability to the `sim` container, so that it can be run as a non-root container. I ran the interop tests with this change and they all have passed.

Does this change look fine and if so can this be accepted in this repo?