### PR TITLE
Use a more portable shebang

### DIFF
--- a/certs.sh
+++ b/certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
e.g. NixOS has no /bin/bash