### PR TITLE
Attempt at fixing msquic

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -50,7 +50,7 @@
     "role": "server"
   },
   "msquic": {
-    "image": "ghcr.io/microsoft/msquic/qns:main",
+    "image": "marcop010/marco-msquic-interop",
     "url": "https://github.com/microsoft/msquic",
     "role": "both"
   },


### PR DESCRIPTION
I was getting weird errors locally, so I'm curious if this passes in CI. 

I think the errors are compose related:
```
Copying logs from server failed: 2 error(s) decoding:

* error decoding 'Volumes[0]': invalid spec: :/www:ro: empty section between colons
* error decoding 'Volumes[1]': invalid spec: :/certs:ro: empty section between colons
must specify at least one container source
```