### PR TITLE
fix: Only return QUIC packets from `_get_packets`

### DIFF
--- a/trace.py
+++ b/trace.py
@@ -113,7 +113,8 @@ class TraceAnalyzer:
         # See https://github.com/KimiNewt/pyshark/issues/390.
         try:
             for p in cap:
-                packets.append(p)
+                if hasattr(p, "quic"):
+                    packets.append(p)
             cap.close()
         except Exception as e:
             logging.debug(e)


### PR DESCRIPTION
Because I'm seeing python aborts when there are ICMP or other packets in the pcap file.