### PR TITLE
fix: Transfer more data during the ECN testcases

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -1138,6 +1138,12 @@ class TestCaseECN(TestCaseHandshake):
     def abbreviation():
         return "E"
 
+    def get_paths(self):
+        # Transfer a bit more data, so that QUIC implementations that do ECN validation after the
+        # handshake have a chance to ACK some ECN marked packets.
+        self._files = [self._generate_random_file(100 * KB)]
+        return self._files
+
     def _count_ecn(self, tr):
         ecn = [0] * (max(ECN) + 1)
         for p in tr:


### PR DESCRIPTION
Some stacks only validate ECN after the handshake. A 1KB transfer can complete before the ECN validation completes, causing a spurious test failure.