### PR TITLE
feat: accept connection ID validation in `amplificationlimit` test

### DIFF
--- a/testcases_quic.py
+++ b/testcases_quic.py
@@ -566,7 +566,10 @@ class TestCaseAmplificationLimit(TestCaseQuic):
                 cid = p.scid.replace(":", "")
                 if len(cid) >= 16:  # 8 bytes = 16 hex characters
                     server_cids.add(p.scid)
-                    logging.debug("Server offered connection ID with sufficient entropy: %s", p.scid)
+                    logging.debug(
+                        "Server offered connection ID with sufficient entropy: %s",
+                        p.scid,
+                    )
 
         # Check that the server didn't send more than 3-4x what the client sent.
         allowed = 0
@@ -598,7 +601,7 @@ class TestCaseAmplificationLimit(TestCaseQuic):
                         if client_dcid in server_cids:
                             logging.debug(
                                 "Client used server-chosen connection ID %s with sufficient entropy. Address validated.",
-                                client_dcid
+                                client_dcid,
                             )
                             res = TestResult.SUCCEEDED
                             break


### PR DESCRIPTION
  feat: accept connection ID validation in amplificationlimit test

  ## Context

  The amplificationlimit test failure criteria implemented by this code was too narrow.
  RFC 9000 Section 8.1 paragraph 2 (https://datatracker.ietf.org/doc/html/rfc9000#section-8.1-2)
  contains an additional criterion for when it's safe to stop applying the amplification limit.
  The interop runner should permit that exit criterion and mark the test as passed.

  The RFC states: "Additionally, an endpoint MAY consider the peer address validated if the
  peer uses a connection ID chosen by the endpoint and the connection ID contains at least
  64 bits of entropy."

  ## Changes

  Updated `TestCaseAmplificationLimit.check()` in `testcases.py` to accept both RFC 9000
  Section 8.1 exit criteria:

  1. **Original criterion**: Server receives a Handshake packet from the client (existing behavior)
  2. **New criterion**: Client uses a server-chosen connection ID with ≥64 bits of entropy

  ### Implementation

  - Added tracking of server-chosen connection IDs from Initial packets (lines 830-841)
  - Filter SCIDs to only include those with at least 8 bytes (64 bits) of entropy
  - Added validation check in packet processing loop (lines 864-876)
  - When client Initial packet uses a matching server-chosen CID, mark address as validated
  - Includes debug logging for visibility into which criterion triggered success

  ## Benefits

  - More accurate RFC 9000 compliance testing
  - Accepts valid server implementations that use connection ID-based address validation
  - Reduces false negatives in interoperability testing

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept server-chosen connection ID validation with ≥64-bit entropy in `TestCaseAmplificationLimit.get_paths_raw` for the `amplificationlimit` test in [testcases_quic.py](https://github.com/quic-interop/quic-interop-runner/pull/442/files#diff-4206ad97572106db46280cf802575fe361b8a02125de61825f750ce13b375ac7)
> Track server Initial `scid` values with ≥16 hex chars, record them in a set, and mark the test as succeeded when a client Initial `dcid` matches, exiting early.
>
> #### 📍Where to Start
> Start in `TestCaseAmplificationLimit.get_paths_raw` in [testcases_quic.py](https://github.com/quic-interop/quic-interop-runner/pull/442/files#diff-4206ad97572106db46280cf802575fe361b8a02125de61825f750ce13b375ac7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1deadb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->