### PR TITLE
fix: This event loop is already running

### DIFF
--- a/trace.py
+++ b/trace.py
@@ -117,9 +117,9 @@ class TraceAnalyzer:
                     logging.info("Captured packet without quic layer: %r", p)
                     continue
                 packets.append(p)
-            cap.close()
         except Exception as e:
             logging.debug(e)
+        cap.close()
 
         if self._keylog_file is not None:
             for p in packets:


### PR DESCRIPTION
https://github.com/KimiNewt/pyshark/issues/366#issuecomment-524746268 says that closing the pcap fixes the issue. I noted that we don't close the pcap if an exception occurs, which leads to errors like this:

```
Server: neqo-main. Client: go-x-net. Running test case: transfercorruption
Unknown child process pid 15841, will report returncode 255
Server: neqo-main. Client: go-x-net. Running test case: ipv6
Exception ignored in: <function Capture.__del__ at 0x7ff3388eee80>
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pyshark/capture/capture.py", line 405, in __del__
    self.close()
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pyshark/capture/capture.py", line 393, in close
    self.eventloop.run_until_complete(self.close_async())
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/asyncio/base_events.py", line 667, in run_until_complete
    self._check_running()
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/asyncio/base_events.py", line 626, in _check_running
Error:     raise RuntimeError('This event loop is already running')
RuntimeError: This event loop is already running
```

Hoping this will fix that issue.