### PR TITLE
fix: relax PATH_CHALLENGE validation

### DIFF
--- a/testcases_quic.py
+++ b/testcases_quic.py
@@ -1010,7 +1010,8 @@ class TestCasePortRebinding(TestCaseTransfer):
         cur = None
         last = None
         paths = set()
-        challenges = set()
+        # Track PATH_CHALLENGE data per path that needs validation.
+        path_challenges = {}
         for p in tr_server:
             cur = self._path(p)
             if last is None:
@@ -1020,7 +1021,9 @@ class TestCasePortRebinding(TestCaseTransfer):
             if last != cur and cur not in paths:
                 paths.add(last)
                 last = cur
-                # Packet on new path, should have a PATH_CHALLENGE frame
+                # Initialize challenge tracking for this new path.
+                path_challenges[cur] = set()
+                # First packet on new path should have a PATH_CHALLENGE frame.
                 if hasattr(p["quic"], "path_challenge.data") is False:
                     logging.info(
                         "First server packet on new path %s did not contain a PATH_CHALLENGE frame",
@@ -1028,9 +1031,13 @@ class TestCasePortRebinding(TestCaseTransfer):
                     )
                     logging.info(p["quic"])
                     return TestResult.FAILED
-                else:
-                    challenges.add(getattr(p["quic"], "path_challenge.data"))
+
+            # Capture all PATH_CHALLENGE frames for paths needing validation.
+            if cur in path_challenges and hasattr(p["quic"], "path_challenge.data"):
+                path_challenges[cur].add(getattr(p["quic"], "path_challenge.data"))
+
         paths.add(cur)
+        final_path = cur
 
         logging.info("Server saw these paths used: %s", paths)
         if len(paths) <= 1:
@@ -1041,18 +1048,27 @@ class TestCasePortRebinding(TestCaseTransfer):
             self._client_trace()._get_direction_filter(Direction.FROM_CLIENT) + " quic"
         )
 
-        responses = list(
-            set(
-                getattr(p["quic"], "path_response.data")
-                for p in tr_client
-                if hasattr(p["quic"], "path_response.data")
-            )
+        responses = set(
+            getattr(p["quic"], "path_response.data")
+            for p in tr_client
+            if hasattr(p["quic"], "path_response.data")
         )
 
-        unresponded = [c for c in challenges if c not in responses]
-        if unresponded != []:
-            logging.info("PATH_CHALLENGE without a PATH_RESPONSE: %s", unresponded)
-            return TestResult.FAILED
+        # Verify each new path has at least one PATH_CHALLENGE that was responded to.
+        # This tolerates packet loss while still proving path validation succeeded.
+        # Exclude the final path, since the peer may close the connection successfully
+        # without responding to a late-arriving PATH_CHALLENGE.
+        for path, challenges in path_challenges.items():
+            if path == final_path:
+                continue
+            if not any(c in responses for c in challenges):
+                logging.info(
+                    "No PATH_RESPONSE received for any PATH_CHALLENGE on path %s "
+                    "(challenges sent: %s)",
+                    path,
+                    challenges,
+                )
+                return TestResult.FAILED
 
         return TestResult.SUCCEEDED
 

--- a/trace.py
+++ b/trace.py
@@ -1,7 +1,29 @@
+import asyncio
 import datetime
 import logging
 from enum import Enum
 from typing import List, Optional, Tuple
+
+# Workaround for pyshark compatibility with Python 3.14+.
+# Child watcher APIs were removed in Python 3.14.
+if not hasattr(asyncio, "SafeChildWatcher"):
+
+    class _DummyChildWatcher:
+        def attach_loop(self, loop):
+            pass
+
+        def close(self):
+            pass
+
+    asyncio.SafeChildWatcher = _DummyChildWatcher
+    asyncio.set_child_watcher = lambda w: None
+    asyncio.get_child_watcher = _DummyChildWatcher
+
+# Ensure an event loop exists for pyshark (required for Python 3.10+).
+try:
+    asyncio.get_running_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
 import pyshark
 


### PR DESCRIPTION
The previous check required every PATH_CHALLENGE to have a matching PATH_RESPONSE, which was too strict because:
- Some PATH_CHALLENGE frames may be lost in transit
- The server may send multiple challenges for redundancy (per RFC 9000 §8.2)
- On the final path, the peer may close the connection successfully without responding to a late-arriving PATH_CHALLENGE

Also add Python 3.14 support, because it was missing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Relax PATH_CHALLENGE validation in `TestCasePortRebinding.transfer` and add asyncio child-watcher shims in [trace.py](https://github.com/quic-interop/quic-interop-runner/pull/460/files#diff-0f750501ce9e650456d1c805e2e3cc65712453f0e19c9bee0eee145cb8f4ddeb) to support Python 3.14+
> Switch to per-path tracking of `PATH_CHALLENGE` values and require at least one matching `PATH_RESPONSE` per non-final path in [testcases_quic.py](https://github.com/quic-interop/quic-interop-runner/pull/460/files#diff-4206ad97572106db46280cf802575fe361b8a02125de61825f750ce13b375ac7); add event-loop initialization and child-watcher shims before importing `pyshark` in [trace.py](https://github.com/quic-interop/quic-interop-runner/pull/460/files#diff-0f750501ce9e650456d1c805e2e3cc65712453f0e19c9bee0eee145cb8f4ddeb).
>
> #### 📍Where to Start
> Start with the revised validation in `TestCasePortRebinding.transfer` in [testcases_quic.py](https://github.com/quic-interop/quic-interop-runner/pull/460/files#diff-4206ad97572106db46280cf802575fe361b8a02125de61825f750ce13b375ac7), then review the asyncio initialization and watcher shims in [trace.py](https://github.com/quic-interop/quic-interop-runner/pull/460/files#diff-0f750501ce9e650456d1c805e2e3cc65712453f0e19c9bee0eee145cb8f4ddeb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ac05ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->