### PR TITLE
web: move results of QUIC runs to logs/quic/

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,7 +16,7 @@ jobs:
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           script: |
             delete_oldest_folder() {
-                OLDEST_DIR=$(find "${{ vars.LOG_DIR }}" -mindepth 1 -maxdepth 1 -type d -printf '%T+ %p\n' | sort | head -n 1 | cut -d" " -f2-)
+                OLDEST_DIR=$(find "${{ vars.LOG_DIR_QUIC }}" -mindepth 1 -maxdepth 1 -type d -printf '%T+ %p\n' | sort | head -n 1 | cut -d" " -f2-)
                 if [[ -n "$OLDEST_DIR" ]]; then
                     echo "Deleting oldest directory: $OLDEST_DIR"
                     rm -rf "$OLDEST_DIR"
@@ -25,7 +25,7 @@ jobs:
 
             # Loop until enough space is available or no directories left to delete
             while true; do
-                AVAILABLE_SPACE_GB=$(df -BG "${{ vars.LOG_DIR }}" | tail -n 1 | awk '{print $4}' | sed 's/G//')
+                AVAILABLE_SPACE_GB=$(df -BG "${{ vars.LOG_DIR_QUIC }}" | tail -n 1 | awk '{print $4}' | sed 's/G//')
                 echo "Available Space: $AVAILABLE_SPACE_GB GB"
 
                 if [[ "$AVAILABLE_SPACE_GB" -lt 50 ]]; then
@@ -38,6 +38,6 @@ jobs:
             done
 
             TEMP_FILE=$(mktemp)
-            find "${{ vars.LOG_DIR }}" -mindepth 1 -maxdepth 1 -type d -not -name 'lost+found' -exec basename {} \; | sort > "$TEMP_FILE"
-            jq -R -s 'split("\n") | map(select(. != ""))' "$TEMP_FILE" > "${{ vars.LOG_DIR }}/logs.json"
+            find "${{ vars.LOG_DIR_QUIC }}" -mindepth 1 -maxdepth 1 -type d -not -name 'lost+found' -exec basename {} \; | sort > "$TEMP_FILE"
+            jq -R -s 'split("\n") | map(select(. != ""))' "$TEMP_FILE" > "${{ vars.LOG_DIR_QUIC }}/logs.json"
             rm -f "$TEMP_FILE"

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           switches: -avzr --relative
           path: logs/./${{ inputs.server }}_${{ matrix.client }}/
-          remote_path: ${{ vars.LOG_DIR }}/${{ inputs.logname }}
+          remote_path: ${{ vars.LOG_DIR_QUIC }}/${{ inputs.logname }}
           remote_host: interop.seemann.io
           remote_user: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           remote_key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           switches: -avzr
           path: result.json
-          remote_path: ${{ vars.LOG_DIR }}/${{ needs.config.outputs.logname }}/
+          remote_path: ${{ vars.LOG_DIR_QUIC }}/${{ needs.config.outputs.logname }}/
           remote_host: interop.seemann.io
           remote_user: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           remote_key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
@@ -163,7 +163,7 @@ jobs:
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           envs: LOGNAME
           script: |
-            cd ${{ vars.LOG_DIR }}
+            cd ${{ vars.LOG_DIR_QUIC }}
             jq '. += [ "${{ needs.config.outputs.logname }}" ]' logs.json | sponge logs.json
             rm latest || true
             ln -s $LOGNAME latest

--- a/web/script.js
+++ b/web/script.js
@@ -24,7 +24,7 @@
     a.className = "btn btn-xs btn-" + color_type[res] + " " + res + " test-" + text.toLowerCase();
     var ttip_target = a;
     if (res !== "unsupported") {
-      a.href = "logs/" + log_dir + "/" + server + "_" + client + "/" + test;
+      a.href = "logs/quic/" + log_dir + "/" + server + "_" + client + "/" + test;
       a.target = "_blank";
       ttip += "<br><br>(Click for logs.)";
     } else {
@@ -272,7 +272,7 @@
     document.getElementById("run-selection-msg").innerHTML = "";
     var xhr = new XMLHttpRequest();
     xhr.responseType = 'json';
-    xhr.open('GET', 'logs/' + dir + '/result.json');
+    xhr.open('GET', 'logs/quic/' + dir + '/result.json');
     xhr.onreadystatechange = function() {
       if(xhr.readyState !== XMLHttpRequest.DONE) return;
       if(xhr.status !== 200) {
@@ -308,7 +308,7 @@
   // enable loading of old runs
   var xhr = new XMLHttpRequest();
   xhr.responseType = 'json';
-  xhr.open('GET', 'logs/logs.json');
+  xhr.open('GET', 'logs/quic/logs.json');
   xhr.onreadystatechange = function() {
     if(xhr.readyState !== XMLHttpRequest.DONE) return;
     if(xhr.status !== 200) {


### PR DESCRIPTION
Note to self: Move files on interop.seemann.io once this PR is merged.

This PR is in preparation for the WebTransport mode, allowing us to separate logs of QUIC and WebTransport runs.
 
I hope that this doesn't again break Firefox's bespoke Interop Runner workflow (cc @mxinden @larseggert)!