### PR TITLE
Add ngtcp2 to webtransport interop runner

### DIFF
--- a/implementations_webtransport.json
+++ b/implementations_webtransport.json
@@ -18,5 +18,10 @@
     "image": "peterdoornbosch/flupke-webtransport-interop",
     "url": "https://github.com/ptrd/flupke",
     "role": "server"
+  },
+  "ngtcp2": {
+    "image": "ghcr.io/ngtcp2/ngtcp2-interop-webtransport:latest",
+    "url": "https://github.com/ngtcp2/ngtcp2/tree/webtransport",
+    "role": "both"
   }
 }


### PR DESCRIPTION
In my private testing, all tests passed except for handshake with firefox which is supposed to fail.

@marten-seemann PTAL



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ngtcp2 to the WebTransport interop runner
> Adds a new `ngtcp2` entry to [implementations_webtransport.json](https://github.com/quic-interop/quic-interop-runner/pull/494/files#diff-62ff908a0b1812c9d6280553f12e974fe96bf078ed933d6005f9af09405c807b) with the container image `ghcr.io/ngtcp2/ngtcp2-interop-webtransport:latest`, repository URL, and role set to `both` (client and server).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdf4213.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->