### PR TITLE
add flupke webtransport client

### DIFF
--- a/implementations_webtransport.json
+++ b/implementations_webtransport.json
@@ -17,7 +17,7 @@
   "flupke-webtransport": {
     "image": "peterdoornbosch/flupke-webtransport-interop",
     "url": "https://github.com/ptrd/flupke",
-    "role": "server"
+    "role": "both"
   },
   "ngtcp2": {
     "image": "ghcr.io/ngtcp2/ngtcp2-interop-webtransport:latest",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add client role to flupke WebTransport implementation entry
Updates the `role` field in [implementations_webtransport.json](https://github.com/quic-interop/quic-interop-runner/pull/495/files#diff-62ff908a0b1812c9d6280553f12e974fe96bf078ed933d6005f9af09405c807b) from `"server"` to `"both"`, reflecting that the flupke implementation supports both client and server roles.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16ad26f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->