### PR TITLE
Add "Post-quantum" test case

### DIFF
--- a/quic.md
+++ b/quic.md
@@ -51,3 +51,5 @@ Unless noted otherwise, test cases use HTTP/0.9 for file transfers. The name in 
 * **Address Rebinding** (`rebind-addr`): A NAT is simulated that changes the client's IP address after the handshake. The server should perform path validation.
 
 * **Connection Migration** (`connectionmigration`): The server provides its preferred addresses to the client during the handshake. The client performs active migration to one of those addresses.
+
+* **Post-quantum** (`post-quantum`): Tests the ability for the client to send a ClientHello that spans at least 2 packets. The client is expected to establish a single QUIC connection to the server with a ClientHello that spanning at least 2 packets, and download one or multiple small files. Servers should not send a Retry packet in this test case.

--- a/testcases_quic.py
+++ b/testcases_quic.py
@@ -1324,6 +1324,70 @@ class TestCaseV2(TestCaseQuic):
         return set([hex(int(p.version, 0)) for p in packets])
 
 
+class TestCasePostQuantum(TestCaseQuic):
+    @staticmethod
+    def name():
+        return "post-quantum"
+
+    @staticmethod
+    def abbreviation():
+        return "PQ"
+    
+    @staticmethod
+    def desc():
+        return "Client should send a ClientHello in two frames or more."
+    
+    def get_paths_raw(self):
+        self._files = [self._generate_random_file(1 * KB)]
+        return self._files
+
+    def check(self) -> TestResult:
+        super().check()
+        if not self._check_version_and_files():
+            return TestResult.FAILED
+        if self._retry_sent():
+            logging.info("Didn't expect a Retry to be sent.")
+            return TestResult.FAILED
+        num_handshakes = self._count_handshakes()
+        if num_handshakes != 1:
+            logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
+            return TestResult.FAILED
+
+        initial_packets = self._client_trace().get_initial(Direction.FROM_CLIENT)
+        client_hello = []
+        for p in initial_packets:
+            if hasattr(p, "tls_handshake") and "Client Hello" in p.tls_handshake:
+                client_hello.append({"start":int(p.crypto_offset), "end":int(p.crypto_offset) + int(p.crypto_length), "packet_number":int(p.packet_number)})
+        client_hello.sort(key=lambda x : x["start"])
+
+        i = 0
+        client_hello_agregated = [dic.copy() for dic in client_hello]
+        while i < len(client_hello_agregated):
+            client_hello_agregated[i]["of_different_packet"] = False
+            for j in range(i + 1, len(client_hello_agregated)):
+                if client_hello_agregated[i]["end"] == client_hello_agregated[j]["start"]:
+                    client_hello_agregated[i]["end"] = client_hello_agregated[j]["end"]
+                    client_hello_agregated[i]["of_different_packet"] =      \
+                        client_hello_agregated[i]["of_different_packet"] or \
+                        client_hello_agregated[i]["packet_number"] != client_hello_agregated[j]["packet_number"]
+                    client_hello_agregated.pop(j)
+                    break
+            i += 1
+
+        if len(client_hello_agregated) != 1:
+            logging.info(
+                "Expected exactly one Client Hello in client Handshake. Got %s", client_hello
+            )
+            return TestResult.FAILED
+
+        if not client_hello_agregated[0]["of_different_packet"]:
+            logging.info(
+                "Expected that the Client Hello is separated between different packets. Got %s", client_hello
+            )
+            return TestResult.FAILED
+        return TestResult.SUCCEEDED
+
+
 class MeasurementGoodput(Measurement):
     FILESIZE = 10 * MB
     _result = 0.0
@@ -1440,6 +1504,7 @@ TESTCASES_QUIC = [
     TestCasePortRebinding,
     TestCaseAddressRebinding,
     TestCaseConnectionMigration,
+    TestCasePostQuantum,
 ]
 
 MEASUREMENTS = [


### PR DESCRIPTION
This is an attempt to solve issue #23 and #305 which, if I understood them correctly, tackle the same issue.

I've thus added a new class `TestCasePostQuantum` that basically takes `TestCaseHandshake` and adds verification of the number of ClientHello. This is done by coalescing the different Crypto frames that are sent by the client and that are ClientHello. At the end, the test is valid if it detects only one ClientHello message that was carried by more than one QUIC packet.

I don't know what is the common way to test a test, so I took the [picoquic-interop-runner](https://github.com/private-octopus/picoquic-interop-runner) repository and build a new docker image that is available here : [resowifix/picoquic](https://hub.docker.com/r/resowifix/picoquic). The test picoquic vs picoquic worked successfully.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add post-quantum test case to the QUIC test suite
> - Adds `TestCasePostQuantum` in [testcases_quic.py](https://github.com/quic-interop/quic-interop-runner/pull/497/files#diff-4206ad97572106db46280cf802575fe361b8a02125de61825f750ce13b375ac7) to verify that the client sends a ClientHello split across at least two Initial packets with no server Retry and exactly one handshake.
> - The check parses client Initial packets, reconstructs CRYPTO frame segments by offset/length, merges contiguous segments, and fails if the ClientHello does not span multiple packet numbers.
> - Generates a ~1 KB random file for the download portion of the test.
> - Documents the new test case in [quic.md](https://github.com/quic-interop/quic-interop-runner/pull/497/files#diff-fc763162e61f76df04bf7473b006a0e137d8a86d8fe68e036fc21550a4101a01) and appends `TestCasePostQuantum` to `TESTCASES_QUIC` so it runs by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31a07e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->