### PR TITLE
add time logging

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Callable, List, Tuple
 import prettytable
 from termcolor import colored
+import time
 
 import testcases_quic
 from result import TestResult
@@ -442,22 +443,28 @@ class InteropRunner:
         logging.debug("Command: %s", cmd)
 
         status = TestResult.FAILED
-        output = ""
         expired = False
+        lines = []
         try:
-            r = subprocess.run(
+            start = time.time()
+            r = subprocess.Popen(
                 cmd,
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                timeout=test.timeout(),
             )
-            output = r.stdout
+            while r.poll() is None:
+                if time.time() - start > test.timeout():
+                    raise subprocess.TimeoutExpired(cmd, test.timeout())
+                line = r.stdout.readline()
+                if line:
+                    logging.debug("| %s", line[:-1].decode("utf-8", errors="replace"))
+                    lines.append(line)
         except subprocess.TimeoutExpired as ex:
             output = ex.stdout
+            if output is not None:
+                logging.debug("%s", output.decode("utf-8", errors="replace"))
             expired = True
-
-        logging.debug("%s", output.decode("utf-8", errors="replace"))
 
         if expired:
             logging.debug("Test failed: took longer than %ds.", test.timeout())
@@ -476,7 +483,6 @@ class InteropRunner:
         self._copy_logs("server", server_log_dir)
 
         if not expired:
-            lines = output.splitlines()
             exit_lines = [
                 str(line) for line in lines if "exited with code" in str(line)
             ]


### PR DESCRIPTION
This is an attempt to address issue #247.
This is a little bit "hand-crafted", but it seems to do the basic job.
I don't know if it is sufficient, or if someone knows how to improve it.

 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream docker-compose output line-by-line during interop test execution
> Replaces the blocking `subprocess.run` call in [interop.py](https://github.com/quic-interop/quic-interop-runner/pull/498/files#diff-a1f0ac428938a846f118f59aa8e2e66b90bff7b498b928204eb3bfcb41f1f528) with `subprocess.Popen` to stream stdout line-by-line to debug logs as the process runs, rather than dumping the full output buffer after completion. Timeout enforcement is reimplemented manually using `time.time()` instead of relying on the subprocess timeout parameter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42aee2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->